### PR TITLE
Precise vector test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1"
 rand = "0.5"
 cgmath = "0.16"
 libm = "0.1.3"
+bigdecimal = "*"
 
 [profile.release]
 debug = 2

--- a/src/r2/point.rs
+++ b/src/r2/point.rs
@@ -17,14 +17,49 @@ limitations under the License.
 
 use consts::*;
 use std;
+use std::cmp::Ordering;
 
 /// Point represents a point in ℝ².
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Point {
     /// x coordinate of the point
     pub x: f64,
     /// y coordinate of the point
     pub y: f64,
+}
+
+impl Eq for Point {}
+
+impl Ord for Point {
+    fn cmp(&self, ov: &Point) -> Ordering {
+        if self.x < ov.x {
+            return Ordering::Less
+        }
+        if self.x > ov.x {
+            return Ordering::Greater
+        }
+
+        // First elements were the same, try the next.
+        if self.y < ov.y {
+            return Ordering::Less
+        }
+        if self.y > ov.y {
+            return Ordering::Greater
+        }
+        return Ordering::Equal
+    }
+}
+
+impl PartialOrd for Point {
+    fn partial_cmp(&self, other: &Point) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Point {
+    fn eq(&self, other: &Point) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
 }
 
 impl std::ops::Add<Point> for Point {

--- a/src/r3/mod.rs
+++ b/src/r3/mod.rs
@@ -1,1 +1,2 @@
 pub mod vector;
+pub mod precisevector;

--- a/src/r3/precisevector.rs
+++ b/src/r3/precisevector.rs
@@ -198,22 +198,16 @@ mod tests {
 	pub fn test_precise_round_trip() {
 
 		let tv = Vector{x:1.0, y:2.0, z:3.0};
-		println!("tv.x: {}", tv.x);
-		let tvnorm = tv.clone().normalize();
-		println!("tvnorm.x: {}", tvnorm.x);
-		let ptv = precisevector::precise_vector_from_vector(tv.clone());
-		println!("ptv.x: {}", ptv.x);
-		let ptvret = ptv.clone().vector();
-		println!("ptvret.x: {}", ptvret.x);
-		println!("----------------------------------------");
-		let nptv = ptv.clone();
-		let x = nptv.x.to_f64().unwrap();
-		let y = nptv.y.to_f64().unwrap();
-		let z = nptv.z.to_f64().unwrap();
-		let manual = Vector{x, y, z}.normalize();
-		println!("tv.x: {}    manual.x: {}", tv.x, nptv.x);
+		let tv_normalized = tv.clone().normalize();
+		let precise_tv = precisevector::precise_vector_from_vector(tv.clone());
+		let precise_tv_converted_and_normalized = precise_tv.clone().vector();
 
-		assert_eq!(tvnorm.x, manual.x);
+		println!("vector.x: {}    			 after_conversion_to_bigdecimal.x: {}", tv.x, precise_tv.x);
+		println!("vector.x normalized: {}    bigdecimal_converted_back_and_normalized.x: {}", tv_normalized.x, precise_tv_converted_and_normalized.x); 
+		println!("");
+		println!("");
+
+		assert_eq!(tv_normalized.x, precise_tv_converted_and_normalized.x);
 
 		assert!(precisevector::precise_vector_from_vector(Vector{x:0.0, y:0.0, z:0.0}).vector() == Vector{x:0.0, y:0.0, z:0.0}.normalize());
 		assert!(precisevector::precise_vector_from_vector(Vector{x:1.0, y:2.0, z:3.0}).vector() == Vector{x:1.0, y:2.0, z:3.0}.normalize());

--- a/src/r3/precisevector.rs
+++ b/src/r3/precisevector.rs
@@ -79,7 +79,7 @@ impl PreciseVector {
 
 	// Norm2 returns the square of the norm.
 	pub fn norm2(&self) -> bigdecimal::BigDecimal {
-		return self.dot(&self.clone());
+		return self.dot(self.clone());
 	}
 
 	// IsUnit reports whether this vector is of unit length.
@@ -132,7 +132,7 @@ impl PreciseVector {
 	}
 
 	// Dot returns the standard dot product of v and ov.
-	pub fn dot(&self, ov: &PreciseVector) -> bigdecimal::BigDecimal{
+	pub fn dot(&self, ov: PreciseVector) -> bigdecimal::BigDecimal{
 		let a = self.clone();
 		let b = ov.clone();
 		return (a.x * b.x) + (a.y * b.y) + (a.z * b.z)
@@ -183,5 +183,209 @@ impl PreciseVector {
         }
 	}
 
+}
+
+#[cfg(test)]
+mod tests {
+
+	use r3::vector::Axis;
+	use r3::precisevector;
+	use r3::vector::Vector;
+	use consts::EPSILON;
+	use r3::precisevector::bigdecimal::ToPrimitive;
+
+	#[test]
+	pub fn test_precise_round_trip() {
+
+		let tv = Vector{x:1.0, y:2.0, z:3.0};
+		println!("tv.x: {}", tv.x);
+		let tvnorm = tv.clone().normalize();
+		println!("tvnorm.x: {}", tvnorm.x);
+		let ptv = precisevector::precise_vector_from_vector(tv.clone());
+		println!("ptv.x: {}", ptv.x);
+		let ptvret = ptv.clone().vector();
+		println!("ptvret.x: {}", ptvret.x);
+		println!("----------------------------------------");
+		let nptv = ptv.clone();
+		let x = nptv.x.to_f64().unwrap();
+		let y = nptv.y.to_f64().unwrap();
+		let z = nptv.z.to_f64().unwrap();
+		let manual = Vector{x, y, z}.normalize();
+		println!("tv.x: {}    manual.x: {}", tv.x, nptv.x);
+
+		assert_eq!(tvnorm.x, manual.x);
+
+		assert!(precisevector::precise_vector_from_vector(Vector{x:0.0, y:0.0, z:0.0}).vector() == Vector{x:0.0, y:0.0, z:0.0}.normalize());
+		assert!(precisevector::precise_vector_from_vector(Vector{x:1.0, y:2.0, z:3.0}).vector() == Vector{x:1.0, y:2.0, z:3.0}.normalize());
+		assert!(precisevector::precise_vector_from_vector(Vector{x:3.0, y:-4.0, z:12.0}).vector() == Vector{x:3.0, y:-4.0, z:12.0});
+		assert!(precisevector::precise_vector_from_vector(Vector{x:1.0, y:1e-16_f64, z:1e-32_f64}).vector() == Vector{x:1.0, y:1e-16_f64, z:1e-32_f64});
+	}
+
+	#[test]
+	pub fn test_precise_is_unit() {
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 0.0).is_unit() == false);
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).is_unit() == true);
+		assert!(precisevector::new_precise_vector(0.0, 1.0, 0.0).is_unit() == true);
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 1.0).is_unit() == true);
+		assert!(precisevector::new_precise_vector(1.0+2.0*EPSILON, 0.0, 0.0).is_unit() == false);
+		assert!(precisevector::new_precise_vector(0.0 * (1.0+EPSILON), 0.0, 0.0).is_unit() == false);
+		assert!(precisevector::new_precise_vector(1.0, 1.0, 1.0).is_unit() == false);
+	}
+
+	#[test]
+	pub fn test_precise_norm2() {
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 0.0).norm2() == precisevector::prec_float(0.0));
+		assert!(precisevector::new_precise_vector(0.0, 1.0, 0.0).norm2() == precisevector::prec_float(1.0));
+		assert!(precisevector::new_precise_vector(1.0, 1.0, 1.0).norm2() == precisevector::prec_float(3.0));
+		assert!(precisevector::new_precise_vector(1.0, 2.0, 3.0).norm2() == precisevector::prec_float(14.0));
+		assert!(precisevector::new_precise_vector(3.0, -4.0, 12.0).norm2() == precisevector::prec_float(169.0));
+	}
+
+	#[test]
+	pub fn test_precise_add() {
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 0.0).add(precisevector::new_precise_vector(0.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)) == true);
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).add(precisevector::new_precise_vector(0.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(1.0, 0.0, 0.0)) == true);
+		assert!(precisevector::new_precise_vector(1.0, 2.0, 3.0).add(precisevector::new_precise_vector(4.0, 5.0, 7.0)).equal(precisevector::new_precise_vector(5.0, 7.0, 10.0)) == true);
+		assert!(precisevector::new_precise_vector(1.0, -3.0, 5.0).add(precisevector::new_precise_vector(1.0, -6.0, -6.0)).equal(precisevector::new_precise_vector(2.0, -9.0, -1.0)) == true);
+	}
+
+	#[test]
+	pub fn test_precise_sub() {
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 0.0).sub(precisevector::new_precise_vector(0.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)) == true);
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).sub(precisevector::new_precise_vector(0.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(1.0, 0.0, 0.0)) == true);
+		assert!(precisevector::new_precise_vector(1.0, 2.0, 3.0).sub(precisevector::new_precise_vector(4.0, 5.0, 7.0)).equal(precisevector::new_precise_vector(-3.0, -3.0, -4.0)) == true);
+		assert!(precisevector::new_precise_vector(1.0, -3.0, 5.0).sub(precisevector::new_precise_vector(1.0, -6.0, -6.0)).equal(precisevector::new_precise_vector(0.0, 3.0, 11.0)) == true);
+	}
+
+	#[test]
+	pub fn test_precise_mul() {
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 0.0).mul(precisevector::prec_float(3.0)).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).mul(precisevector::prec_float(1.0)).equal(precisevector::new_precise_vector(1.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).mul(precisevector::prec_float(0.0)).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).mul(precisevector::prec_float(3.0)).equal(precisevector::new_precise_vector(3.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, -3.0, 5.0).mul(precisevector::prec_float(-1.0)).equal(precisevector::new_precise_vector(-1.0, 3.0, -5.0)));
+		assert!(precisevector::new_precise_vector(1.0, -3.0, 5.0).mul(precisevector::prec_float(2.0)).equal(precisevector::new_precise_vector(2.0, -6.0, 10.0)));
+	}
+
+	#[test]
+	pub fn test_precise_mul_by_f64() {
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 0.0).mul_by_f64(3.0).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).mul_by_f64(1.0).equal(precisevector::new_precise_vector(1.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).mul_by_f64(0.0).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).mul_by_f64(3.0).equal(precisevector::new_precise_vector(3.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, -3.0, 5.0).mul_by_f64(-1.0).equal(precisevector::new_precise_vector(-1.0, 3.0, -5.0)));
+		assert!(precisevector::new_precise_vector(1.0, -3.0, 5.0).mul_by_f64(2.0).equal(precisevector::new_precise_vector(2.0, -6.0, 10.0)));
+	}
+
+	#[test]
+	pub fn test_precise_dot() {
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).dot(precisevector::new_precise_vector(1.0, 0.0, 0.0)) == precisevector::prec_float(1.0));
+		assert!(precisevector::new_precise_vector(0.0, 1.0, 0.0).dot(precisevector::new_precise_vector(0.0, 1.0, 0.0)) == precisevector::prec_float(1.0));
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 1.0).dot(precisevector::new_precise_vector(0.0, 0.0, 1.0)) == precisevector::prec_float(1.0));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).dot(precisevector::new_precise_vector(0.0, 1.0, 0.0)) == precisevector::prec_float(0.0));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).dot(precisevector::new_precise_vector(0.0, 1.0, 1.0)) == precisevector::prec_float(0.0));
+		assert!(precisevector::new_precise_vector(1.0, 1.0, 1.0).dot(precisevector::new_precise_vector(-1.0, -1.0, -1.0)) == precisevector::prec_float(-3.0));
+	}
+
+	#[test]
+	pub fn test_precise_cross() {
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).cross(precisevector::new_precise_vector(1.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(0.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(1.0, 0.0, 0.0).cross(precisevector::new_precise_vector(0.0, 1.0, 0.0)).equal(precisevector::new_precise_vector(0.0, 0.0, 1.0)));
+		assert!(precisevector::new_precise_vector(0.0, 1.0, 0.0).cross(precisevector::new_precise_vector(0.0, 0.0, 1.0)).equal(precisevector::new_precise_vector(1.0, 0.0, 0.0)));
+		assert!(precisevector::new_precise_vector(0.0, 0.0, 1.0).cross(precisevector::new_precise_vector(1.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(0.0, 1.0, 0.0)));
+		assert!(precisevector::new_precise_vector(0.0, 1.0, 0.0).cross(precisevector::new_precise_vector(1.0, 0.0, 0.0)).equal(precisevector::new_precise_vector(0.0, 0.0, -1.0)));
+		assert!(precisevector::new_precise_vector(1.0, 2.0, 3.0).cross(precisevector::new_precise_vector(-4.0, 5.0, -6.0)).equal(precisevector::new_precise_vector(-27.0, -6.0, 13.0)));
+	}
+
+	#[test]
+	pub fn test_precise_identities() {
+		let v1 = precisevector::new_precise_vector(0.0, 0.0, 0.0);
+		let v2 = precisevector::new_precise_vector(0.0, 0.0, 0.0);
+		let c1 = v1.cross(v2.clone());
+		let c2 = v2.cross(v1.clone());
+		let d1 = v1.dot(v2.clone());
+		let d2 = v2.dot(v1.clone());
+		assert!(d1 == d2);
+		assert!(c1.equal(c2.mul_by_f64(-1.0)) == true);
+		assert!(v1.dot(c1.clone()) == precisevector::prec_float(0.0));
+		assert!(v2.dot(c1.clone()) == precisevector::prec_float(0.0));
+
+		let v1 = precisevector::new_precise_vector(0.0, 0.0, 0.0);
+		let v2 = precisevector::new_precise_vector(0.0, 1.0, 2.0);
+		let c1 = v1.cross(v2.clone());
+		let c2 = v2.cross(v1.clone());
+		let d1 = v1.dot(v2.clone());
+		let d2 = v2.dot(v1.clone());
+		assert!(d1 == d2);
+		assert!(c1.equal(c2.mul_by_f64(-1.0)) == true);
+		assert!(v1.dot(c1.clone()) == precisevector::prec_float(0.0));
+		assert!(v2.dot(c1.clone()) == precisevector::prec_float(0.0));
+
+		let v1 = precisevector::new_precise_vector(1.0, 0.0, 0.0);
+		let v2 = precisevector::new_precise_vector(0.0, 1.0, 0.0);
+		let c1 = v1.cross(v2.clone());
+		let c2 = v2.cross(v1.clone());
+		let d1 = v1.dot(v2.clone());
+		let d2 = v2.dot(v1.clone());
+		assert!(d1 == d2);
+		assert!(c1.equal(c2.mul_by_f64(-1.0)) == true);
+		assert!(v1.dot(c1.clone()) == precisevector::prec_float(0.0));
+		assert!(v2.dot(c1.clone()) == precisevector::prec_float(0.0));
+
+		let v1 = precisevector::new_precise_vector(1.0, 0.0, 0.0);
+		let v2 = precisevector::new_precise_vector(0.0, 1.0, 1.0);
+		let c1 = v1.cross(v2.clone());
+		let c2 = v2.cross(v1.clone());
+		let d1 = v1.dot(v2.clone());
+		let d2 = v2.dot(v1.clone());
+		assert!(d1 == d2);
+		assert!(c1.equal(c2.mul_by_f64(-1.0)) == true);
+		assert!(v1.dot(c1.clone()) == precisevector::prec_float(0.0));
+		assert!(v2.dot(c1.clone()) == precisevector::prec_float(0.0));
+
+		let v1 = precisevector::new_precise_vector(1.0, 1.0, 1.0);
+		let v2 = precisevector::new_precise_vector(-1.0, -1.0, -1.0);
+		let c1 = v1.cross(v2.clone());
+		let c2 = v2.cross(v1.clone());
+		let d1 = v1.dot(v2.clone());
+		let d2 = v2.dot(v1.clone());
+		assert!(d1 == d2);
+		assert!(c1.equal(c2.mul_by_f64(-1.0)) == true);
+		assert!(v1.dot(c1.clone()) == precisevector::prec_float(0.0));
+		assert!(v2.dot(c1.clone()) == precisevector::prec_float(0.0));
+
+		let v1 = precisevector::new_precise_vector(1.0, 2.0, 2.0);
+		let v2 = precisevector::new_precise_vector(-0.3, 0.4, -1.2);
+		let c1 = v1.cross(v2.clone());
+		let c2 = v2.cross(v1.clone());
+		let d1 = v1.dot(v2.clone());
+		let d2 = v2.dot(v1.clone());
+		assert!(d1 == d2);
+		assert!(c1.equal(c2.mul_by_f64(-1.0)) == true);
+		assert!(v1.dot(c1.clone()) == precisevector::prec_float(0.0));
+		assert!(v2.dot(c1.clone()) == precisevector::prec_float(0.0));
+	}
+
+	#[test]
+	pub fn test_precise_largest_smallest_components() {
+		let v1 = precisevector::new_precise_vector(0.0, 0.0, 0.0);
+		assert!(v1.largest_component() == Axis::Z);
+		assert!(v1.smallest_component() == Axis::Z);
+		let v1 = precisevector::new_precise_vector(1.0, 0.0, 0.0);
+		assert!(v1.largest_component() == Axis::X);
+		assert!(v1.smallest_component() == Axis::Z);
+		let v1 = precisevector::new_precise_vector(1.0, -1.0, 0.0);
+		assert!(v1.largest_component() == Axis::Y);
+		assert!(v1.smallest_component() == Axis::Z);
+		let v1 = precisevector::new_precise_vector(-1.0, -1.1, -1.1);
+		assert!(v1.largest_component() == Axis::Z);
+		assert!(v1.smallest_component() == Axis::X);
+		let v1 = precisevector::new_precise_vector(0.5, -0.4, -0.5);
+		assert!(v1.largest_component() == Axis::Z);
+		assert!(v1.smallest_component() == Axis::Y);
+		let v1 = precisevector::new_precise_vector(1e-15, 1e-14, 1e-13);
+		assert!(v1.largest_component() == Axis::Z);
+		assert!(v1.smallest_component() == Axis::X);
+	} 
 }
 

--- a/src/r3/precisevector.rs
+++ b/src/r3/precisevector.rs
@@ -188,31 +188,38 @@ impl PreciseVector {
 #[cfg(test)]
 mod tests {
 
+	use std::num;
 	use r3::vector::Axis;
 	use r3::precisevector;
 	use r3::vector::Vector;
 	use consts::EPSILON;
-	use r3::precisevector::bigdecimal::ToPrimitive;
 
 	#[test]
 	pub fn test_precise_round_trip() {
 
-		let tv = Vector{x:1.0, y:2.0, z:3.0};
-		let tv_normalized = tv.clone().normalize();
-		let precise_tv = precisevector::precise_vector_from_vector(tv.clone());
-		let precise_tv_converted_and_normalized = precise_tv.clone().vector();
+		let pvn = precisevector::precise_vector_from_vector(Vector{x:0.0, y:0.0, z:0.0}).vector();
+		let nvn = Vector{x:0.0, y:0.0, z:0.0}.normalize();
+		assert!((pvn.x - nvn.x).abs() <= 0.0000000000001);
+		assert!((pvn.y - nvn.y).abs() <= 0.0000000000001);
+		assert!((pvn.z - nvn.z).abs() <= 0.0000000000001);
 
-		println!("vector.x: {}    			 after_conversion_to_bigdecimal.x: {}", tv.x, precise_tv.x);
-		println!("vector.x normalized: {}    bigdecimal_converted_back_and_normalized.x: {}", tv_normalized.x, precise_tv_converted_and_normalized.x); 
-		println!("");
-		println!("");
+		let pvn = precisevector::precise_vector_from_vector(Vector{x:1.0, y:2.0, z:3.0}).vector();
+		let nvn = Vector{x:1.0, y:2.0, z:3.0}.normalize();
+		assert!((pvn.x - nvn.x).abs() <= 0.0000000000001);
+		assert!((pvn.y - nvn.y).abs() <= 0.0000000000001);
+		assert!((pvn.z - nvn.z).abs() <= 0.0000000000001);
 
-		assert_eq!(tv_normalized.x, precise_tv_converted_and_normalized.x);
+		let pvn = precisevector::precise_vector_from_vector(Vector{x:3.0, y:-4.0, z:12.0}).vector();
+		let nvn = Vector{x:3.0, y:-4.0, z:12.0}.normalize();
+		assert!((pvn.x - nvn.x).abs() <= 0.0000000000001);
+		assert!((pvn.y - nvn.y).abs() <= 0.0000000000001);
+		assert!((pvn.z - nvn.z).abs() <= 0.0000000000001);
 
-		assert!(precisevector::precise_vector_from_vector(Vector{x:0.0, y:0.0, z:0.0}).vector() == Vector{x:0.0, y:0.0, z:0.0}.normalize());
-		assert!(precisevector::precise_vector_from_vector(Vector{x:1.0, y:2.0, z:3.0}).vector() == Vector{x:1.0, y:2.0, z:3.0}.normalize());
-		assert!(precisevector::precise_vector_from_vector(Vector{x:3.0, y:-4.0, z:12.0}).vector() == Vector{x:3.0, y:-4.0, z:12.0});
-		assert!(precisevector::precise_vector_from_vector(Vector{x:1.0, y:1e-16_f64, z:1e-32_f64}).vector() == Vector{x:1.0, y:1e-16_f64, z:1e-32_f64});
+		let pvn = precisevector::precise_vector_from_vector(Vector{x:1.0, y:1e-16, z:1e-32}).vector();
+		let nvn = Vector{x:1.0, y:1e-16, z:1e-32}.normalize();
+		assert!((pvn.x - nvn.x).abs() <= 0.0000000000001);
+		assert!((pvn.y - nvn.y).abs() <= 0.0000000000001);
+		assert!((pvn.z - nvn.z).abs() <= 0.0000000000001);
 	}
 
 	#[test]

--- a/src/r3/precisevector.rs
+++ b/src/r3/precisevector.rs
@@ -1,0 +1,187 @@
+/*
+Copyright 2019 Alexander Haynes. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+extern crate bigdecimal;
+
+//use std;
+use r3;
+use std::str::FromStr;
+use r3::precisevector::bigdecimal::ToPrimitive;
+
+pub fn prec_str(s: String) -> bigdecimal::BigDecimal {
+	let f = bigdecimal::BigDecimal::from_str(&s).unwrap();
+	return f
+}
+
+pub fn prec_int(i: i64) -> bigdecimal::BigDecimal {
+	return bigdecimal::BigDecimal::from(i);
+}
+
+pub fn prec_float(f: f64) -> bigdecimal::BigDecimal {
+	return bigdecimal::BigDecimal::from(f);
+}
+
+
+// PreciseVector represents a point in ℝ³ using high-precision values.
+// Note that this is NOT a complete implementation because there are some
+// operations that Vector supports that are not feasible with arbitrary precision
+// math. (e.g., methods that need divison like Normalize, or methods needing a
+// square root operation such as Norm)
+#[derive(Clone)]
+pub struct PreciseVector {
+	x: bigdecimal::BigDecimal, 
+	y: bigdecimal::BigDecimal, 
+	z: bigdecimal::BigDecimal
+}
+
+// PreciseVectorFromVector creates a high precision vector from the given Vector.
+pub fn precise_vector_from_vector(v: r3::vector::Vector) -> PreciseVector {
+	return new_precise_vector(v.x, v.y, v.z)
+}
+
+// NewPreciseVector creates a high precision vector from the given floating point values.
+pub fn new_precise_vector(x: f64, y: f64, z: f64) -> PreciseVector {
+	return PreciseVector{
+		x: prec_float(x),
+		y: prec_float(y),
+		z: prec_float(z),
+	}
+}
+
+impl PreciseVector {
+
+	// Vector returns this precise vector converted to a Vector.
+	pub fn vector(&self) -> r3::vector::Vector {
+		// The accuracy flag is ignored on these conversions back to float64.
+		let x = self.x.to_f64().unwrap();
+		let y = self.y.to_f64().unwrap();
+		let z = self.z.to_f64().unwrap();
+		return r3::vector::Vector{x, y, z}.normalize()
+	}
+
+	// Equal reports whether v and ov are equal.
+	pub fn equal(&self, ov: PreciseVector) -> bool {
+		return self.x == ov.x && self.y == ov.y && self.z == ov.z
+	}
+
+	// Norm2 returns the square of the norm.
+	pub fn norm2(&self) -> bigdecimal::BigDecimal {
+		return self.dot(&self.clone());
+	}
+
+	// IsUnit reports whether this vector is of unit length.
+	pub fn is_unit(&self) -> bool {
+		return self.norm2() == prec_int(1_i64);
+	}
+
+	// Abs returns the vector with nonnegative components.
+	pub fn abs(&self) -> PreciseVector {
+		return PreciseVector{
+			x: bigdecimal::BigDecimal::abs(&self.x),
+			y: bigdecimal::BigDecimal::abs(&self.y),
+			z: bigdecimal::BigDecimal::abs(&self.z)
+		}
+	}
+
+	// Add returns the standard vector sum of v and ov.
+	pub fn add(&self, ov: PreciseVector) -> PreciseVector {
+		let v = self.clone();
+		return PreciseVector{
+			x: v.x +ov.x,
+			y: v.y +ov.y,
+			z: v.z +ov.z
+		}
+	}
+
+	// Sub returns the standard vector difference of v and ov.
+	pub fn sub(&self, ov: PreciseVector) -> PreciseVector {
+		let v = self.clone();
+		return PreciseVector{
+			x: v.x - ov.x,
+			y: v.y - ov.y,
+			z: v.z - ov.z,
+		}
+	}
+
+	// Mul returns the standard scalar product of v and f.
+	pub fn mul(&self, f: bigdecimal::BigDecimal) -> PreciseVector {
+		let v = self.clone();
+		return PreciseVector{
+			x: v.x * f.clone(),
+			y: v.y * f.clone(),
+			z: v.z * f.clone(),
+		}
+	}
+
+	// MulByFloat64 returns the standard scalar product of v and f.
+	pub fn mul_by_f64(&self, f: f64) -> PreciseVector {
+		return self.mul(prec_float(f))
+	}
+
+	// Dot returns the standard dot product of v and ov.
+	pub fn dot(&self, ov: &PreciseVector) -> bigdecimal::BigDecimal{
+		let a = self.clone();
+		let b = ov.clone();
+		return (a.x * b.x) + (a.y * b.y) + (a.z * b.z)
+	}
+
+	// Cross returns the standard cross product of v and ov.
+	pub fn cross(&self, ov: PreciseVector) -> PreciseVector {
+		return PreciseVector{
+			x: (self.y.clone() * ov.z.clone()) - (self.z.clone() * ov.y.clone()),
+			y: (self.z.clone() * ov.x.clone()) - (self.x.clone() * ov.z.clone()),
+			z: (self.x.clone() * ov.y.clone()) - (self.y.clone() * ov.x.clone())
+		}
+	}
+
+	// LargestComponent returns the axis that represents the largest component in this vector.
+	pub fn largest_component(&self) -> r3::vector::Axis {
+		let a = self.abs();
+        if a.x > a.y {
+            if a.x > a.z {
+                r3::vector::Axis::X
+            } else {
+                r3::vector::Axis::Z
+            }
+        } else {
+            if a.y > a.z {
+                r3::vector::Axis::Y
+            } else {
+                r3::vector::Axis::Z
+            }
+        }
+	}
+
+	// SmallestComponent returns the axis that represents the smallest component in this vector.
+	pub fn smallest_component(&self) -> r3::vector::Axis {
+		let t = self.abs();
+        if t.x < t.y {
+            if t.x < t.z {
+                r3::vector::Axis::X
+            } else {
+                r3::vector::Axis::Z
+            }
+        } else {
+            if t.y < t.z {
+                r3::vector::Axis::Y
+            } else {
+                r3::vector::Axis::Z
+            }
+        }
+	}
+
+}
+

--- a/src/r3/vector.rs
+++ b/src/r3/vector.rs
@@ -226,6 +226,34 @@ impl Vector {
             }
         }
     }
+
+    pub fn cmp(&self, ov: Vector) -> i64 {
+        if self.x < ov.x {
+            return -1
+        }
+        if self.x > ov.x {
+            return 1
+        }
+
+        // First elements were the same, try the next.
+        if self.y < ov.y {
+            return -1
+        }
+        if self.y > ov.y {
+            return 1
+        }
+
+        // Second elements were the same return the final compare.
+        if self.z < ov.z {
+            return -1
+        }
+        if self.z > ov.z {
+            return 1
+        }
+
+        // Both are equal
+        return 0
+    }
 }
 
 /// Axis enumerates the 3 axes of ℝ³.

--- a/src/s2/edge_clipping.rs
+++ b/src/s2/edge_clipping.rs
@@ -1,0 +1,743 @@
+#[allow(dead_code)]
+/*
+Copyright 2014 Google Inc. All rights reserved.
+Copyright 2017 Jihyun Yu. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains a collection of methods for:
+//
+//   (1) Robustly clipping geodesic edges to the faces of the S2 biunit cube
+//       (see s2stuv), and
+//
+//   (2) Robustly clipping 2D edges against 2D rectangles.
+//
+// These functions can be used to efficiently find the set of CellIDs that
+// are intersected by a geodesic edge (e.g., see crossing_edge_query).
+
+use consts::*;
+use point::Point;
+use r2;
+use r3;
+use r1;
+use s2::stuv;
+
+// EDGE_CLIP_ERROR_UV_COORD is the maximum error in a u- or v-coordinate compared to the exact result, assuming that the points A and B are in
+// the rectangle [-1,1]x[1,1] or slightly outside it (by 1e-10 or less).
+#[allow(dead_code)]
+const EDGE_CLIP_ERROR_UV_COORD: f64 = 2.25 * DBL_EPSILON;
+
+// EDGE_CLIP_ERORR_UV_DIST is the maximum distance from a clipped point to
+// the corresponding exact result. It is equal to the error in a single
+// coordinate because at most one coordinate is subject to error.
+#[allow(dead_code)]
+const EDGE_CLIP_ERROR_UV_DIST: f64 = 2.25 * DBL_EPSILON;
+
+// faceClipErrorRadians is the maximum angle between a returned vertex
+// and the nearest point on the exact edge AB. It is equal to the
+// maximum directional error in PointCross, plus the error when
+// projecting points onto a cube face
+const FACE_CLIP_ERROR_RADIANS: f64 = 3.0 * DBL_EPSILON;
+
+// faceClipErrorDist is the same angle expressed as a maximum distance
+// in (u,v)-space. In other words, a returned vertex is at most this far
+// from the exact edge AB projected into (u,v)-space.
+#[allow(dead_code)]
+const FACE_CLIP_ERROR_UV_DIST: f64 = 9.0 * DBL_EPSILON;
+
+// faceClipErrorUVCoord is the maximum angle between a returned vertex
+// and the nearest point on the exact edge AB expressed as the maximum error
+// in an individual u- or v-coordinate. In other words, for each
+// returned vertex there is a point on the exact edge AB whose u- and
+// v-coordinates differ from the vertex by at most this amount
+const FACE_CLIP_ERROR_UV_COORD: f64 = 9.0 * (1.0 / std::f64::consts::SQRT_2) * DBL_EPSILON;
+
+// intersectsRectErrorUVDist is the maximum error when computing if a point
+// intersects with a given Rect. If some point of AB is inside the
+// rectangle by at least this distance, the result is guaranteed to be true;
+// if all points of AB are outside the rectangle by at least this distance,
+// the result is guaranteed to be false. This bound assumes that rect is
+// a subset of the rectangle [-1,1]x[-1,1] or extends slightly outside it
+// (e.g., by 1e-10 or less)
+#[allow(dead_code)]
+const INTERSECT_RECT_ERROR_UV_DIST: f64 = 3.0 * std::f64::consts::SQRT_2 * DBL_EPSILON;
+
+// clip_to_face returns the (u,v) coordinates for the portion of the edge AB that
+// intersects the given face, or false if the edge AB does not intersect.
+// This method guarantees that the clipped vertices lie within the [-1,1]x[-1,1]
+// cube face rectangle and are within faceClipErrorUVDist of the line AB, but
+// the results may differ from those produced by FaceSegments.
+pub fn clip_to_face(a: Point, b: Point, face: u8) -> (r2::point::Point, r2::point::Point, bool) {
+    clip_to_padded_face(a, b, face, 0.0)
+}
+
+// clip_to_padded_face returns the (u,v) coordinates for the portion of the edge AB that
+// intersects the given face, but rather than clipping to the square [-1,1]x[-1,1]
+// in (u,v) space, this method clips to [-R,R]x[-R,R] where R=(1+padding).
+// Padding must be non-negative.
+pub fn clip_to_padded_face(a: Point, b: Point, f: u8, padding: f64) -> (r2::point::Point, r2::point::Point, bool) {
+    // Fast path: both endpoints are on the given face
+    if stuv::face(&a.0) == f && stuv::face(&b.0) == f {
+        let (au, av) = stuv::valid_face_xyz_to_uv(f, &a.0);
+        let (bu, bv) = stuv::valid_face_xyz_to_uv(f, &a.0);
+        return (r2::point::Point{x: au, y: av}, r2::point::Point{x: bu, y: bv}, true)
+    }
+
+    // Convert everything into the (u,v,w) coordinates of the given face. Note
+	// that the cross product *must* be computed in the original (x,y,z)
+	// coordinate system because PointCross (unlike the mathematical cross
+	// product) can produce different results in different coordinate systems
+	// when one argument is a linear multiple of the other, due to the use of
+	// symbolic perturbations.
+    let mut norm_uvw: PointUVW = stuv::face_xyz_to_uvw(f, &a.cross(&b));
+    let a_uvw: PointUVW = stuv::face_xyz_to_uvw(f, &a);
+    let b_uvw: PointUVW = stuv::face_xyz_to_uvw(f, &b);
+
+	// Padding is handled by scaling the u- and v-components of the normal.
+	// Letting R=1+padding, this means that when we compute the dot product of
+	// the normal with a cube face vertex (such as (-1,-1,1)), we will actually
+	// compute the dot product with the scaled vertex (-R,-R,1). This allows
+	// methods such as intersectsFace, exitAxis, etc, to handle padding
+	// with no further modifications.
+    let scale_uv = 1.0 + padding;
+    let scaled_n: PointUVW = Point(r3::vector::Vector{x: scale_uv * norm_uvw.0.x, y: scale_uv * norm_uvw.0.y, z: norm_uvw.0.z});
+    if !scaled_n.intersects_face(){ 
+        return (r2::point::Point{x: 0.0, y:0.0}, r2::point::Point{x: 0.0, y:0.0}, false)
+     }
+    let ldexp = |x: f64, exp: f64| -> f64 {
+        x * (exp.exp2() as f64) 
+    };
+
+    // TODO: This is a workaround for extremely small vectors where some
+	// loss of precision can occur in Normalize causing underflow. When PointCross
+	// is updated to work around this, this can be removed.
+    if norm_uvw.0.x.abs().max(norm_uvw.0.y.abs().max(norm_uvw.0.z.abs())) < ldexp(1.0, -511.0) {
+        norm_uvw = norm_uvw * ldexp(1.0, 563.0)
+    }
+    norm_uvw = norm_uvw.normalize();
+    let a_tan = norm_uvw.cross(&a_uvw);
+    let b_tan = norm_uvw.cross(&b_uvw);
+
+    // As described in clipDestination, if the sum of the scores from clipping the two
+	// endpoints is 3 or more, then the segment does not intersect this face
+    let (a_uv, a_score) = clip_destination(b_uvw, a_uvw, scaled_n * -1_f64, b_tan, a_tan, scale_uv);
+    let (b_uv, b_score) = clip_destination(a_uvw, b_uvw, scaled_n * -1_f64, a_tan, b_tan, scale_uv);
+
+    (a_uv, b_uv, a_score+b_score < 3)
+}
+ 
+// clip_edge returns the portion of the edge defined by AB that is contained by the
+// given rectangle. If there is no intersection, false is returned and aClip and bClip
+// are undefined.
+pub fn clip_edge(a: r2::point::Point, b: r2::point::Point, clip: r2::rect::Rect) -> (r2::point::Point, r2::point::Point, bool) {
+    // Compute the bounding rectangle of AB, clip it, and then extract the new
+	// endpoints from the clipped bound
+    let bound = r2::rect::Rect::from_points(&[a,b]);
+    let (bound, intersects) = clip_edge_bound(a, b, clip, bound); 
+    if !intersects {
+        return (
+            r2::point::Point{x: 0.0, y: 0.0},
+            r2::point::Point{x: 0.0, y: 0.0},
+            intersects
+        )
+    }
+    let ai = if a.x > b.x {
+        1
+    } else {
+        0
+    };
+
+    let aj = if a.y > b.y {
+        1
+    } else {
+        0
+    };
+    (bound.vertex_ij(ai, aj), bound.vertex_ij(1-ai, 1-aj), true)
+}
+
+// The three functions below (sumEqual, intersectsFace, intersectsOppositeEdges)
+// all compare a sum (u + v) to a third value w. They are implemented in such a
+// way that they produce an exact result even though all calculations are done
+// with ordinary floating-point operations. Here are the principles on which these
+// functions are based:
+//
+// A. If u + v < w in floating-point, then u + v < w in exact arithmetic.
+//
+// B. If u + v < w in exact arithmetic, then at least one of the following
+//    expressions is true in floating-point:
+//       u + v < w
+//       u < w - v
+//       v < w - u
+//
+// Proof: By rearranging terms and substituting ">" for "<", we can assume
+// that all values are non-negative.  Now clearly "w" is not the smallest
+// value, so assume WLOG that "u" is the smallest.  We want to show that
+// u < w - v in floating-point.  If v >= w/2, the calculation of w - v is
+// exact since the result is smaller in magnitude than either input value,
+// so the result holds.  Otherwise we have u <= v < w/2 and w - v >= w/2
+// (even in floating point), so the result also holds.
+
+// sum_equal reports whether u + v == w exactly.
+fn sum_equal(u: f64, v: f64, w: f64) -> bool {
+	(u+v == w) && (u == w-v) && (v == w-u)
+}
+
+#[derive(Clone,Copy,PartialEq,Debug)]
+enum Axis {
+    AxisU,
+    AxisV,
+}
+
+impl Axis {
+    fn value(self) -> u8 {
+        match self {
+            Axis::AxisU => 0,
+            Axis::AxisV => 1,
+        }
+    }
+}
+
+type PointUVW = Point;
+
+impl PointUVW {
+    fn intersects_face(self) -> bool {
+        // L intersects the [-1,1]x[-1,1] square in (u,v) if and only if the dot
+        // products of N with the four corner vertices (-1,-1,1), (1,-1,1), (1,1,1),
+        // and (-1,1,1) do not all have the same sign. This is true exactly when
+        // |Nu| + |Nv| >= |Nw|. The code below evaluates this expression exactly.
+        let u = self.0.x.abs();
+        let v = self.0.y.abs();
+        let w = self.0.z.abs();
+
+        // We only need to consider the cases where u or v is the smallest value,
+        // since if w is the smallest then both expressions below will have a
+        // positive LHS and a negative RHS
+        (v >= w-u) && (u >= w-v)
+    }
+
+    
+
+    // intersects_opposite_edges reports whether a directed line L intersects two
+    // opposite edges of a cube face F. This includs the case where L passes
+    // exactly through a corner vertex of F. The directed line L is defined
+    // by its normal N in the (u,v,w) coordinates of F.
+    fn intersects_opposite_edges(self) -> bool {
+        // The line L intersects opposite edges of the [-1,1]x[-1,1] (u,v) square if
+        // and only exactly two of the corner vertices lie on each side of L. This
+        // is true exactly when ||Nu| - |Nv|| >= |Nw|. The code below evaluates this
+        // expression exactly.
+        let u = self.0.x.abs();
+        let v = self.0.y.abs();
+        let w = self.0.z.abs();
+
+        // If w is the smallest, the following line returns an exact result
+        if (u-v).abs() != w {
+            return (u-v).abs() >= w
+        }
+
+        // Otherwise u - v = w exactly, or w is not the smallest value. In either
+        // case the following returns the correct result.
+        if u >= v {
+            return u-w >= v
+        }
+        v-w >= u
+    }
+
+    // exitAxis reports which axis the directed line L exits the cube face F on.
+    // The directed line L is represented by its CCW normal N in the (u,v,w) coordinates
+    // of F. It returns axisU if L exits through the u=-1 or u=+1 edge, and axisV if L exits
+    // through the v=-1 or v=+1 edge. Either result is acceptable if L exits exactly
+    // through a corner vertex of the cube face
+    fn exit_axis(self) -> Axis {
+        if self.intersects_opposite_edges() {
+            // The line passes through through opposite edges of the face.
+            // It exits through the v=+1 or v=-1 edge if the u-component of N has a
+            // larger absolute magnitude than the v-component.
+            if self.0.x.abs() >= self.0.y.abs(){
+                return Axis::AxisV
+            }
+            return Axis::AxisU
+        }
+
+        // The line passes through through two adjacent edges of the face.
+        // It exits the v=+1 or v=-1 edge if an even number of the components of N
+        // are negative. We test this using signbit() rather than multiplication
+        // to avoid the possibility of underflow.
+        let signbit = |n: f64| -> u32 {
+            if n.is_sign_negative() {
+                1
+            } else {
+                0
+            }
+        };
+
+        let x = signbit(self.0.x);
+        let y = signbit(self.0.y);
+        let z = signbit(self.0.z);
+        if x^y^z == 0 {
+            Axis::AxisV
+        } else {
+            Axis::AxisU
+        }
+    }
+
+    // exitPoint returns the UV coordinates of the point where a directed line L (represented
+    // by the CCW normal of this point), exits the cube face this point is derived from along
+    // the given axis
+    fn exit_point(self, a: Axis) -> r2::point::Point {
+        if a == Axis::AxisU {
+            let mut u = -1.0;
+            if self.0.y > 0.0 {
+                u = 1.0
+            }
+            return r2::point::Point{x: u, y: (-u*self.0.x - self.0.z) / self.0.y}
+        }
+
+        let mut v = -1.0;
+        if self.0.x < 0.0 {
+            v = 1.0
+        }
+        return r2::point::Point{x: (-v*self.0.y - self.0.z) / self.0.x, y: v}
+    }
+}
+
+// clip_destination returns a score which is used to indicate if the clipped edge AB
+// on the given face intersects the face at all. This function returns the score for
+// the given endpoint, which is an integer ranging from 0 to 3. If the sum of the scores
+// from both of the endpoints is 3 or more, then edge AB does not intersect this face.
+//
+// First, it clips the line segment AB to find the clipped destination B' on a given
+// face. (The face is specified implicitly by expressing *all arguments* in the (u,v,w)
+// coordinates of that face.) Second, it partially computes whether the segment AB
+// intersects this face at all. The actual condition is fairly complicated, but it
+// turns out that it can be expressed as a "score" that can be computed independently
+// when clipping the two endpoints A and B.
+fn clip_destination(a: PointUVW, b: PointUVW, scaled_n: PointUVW, a_tan: PointUVW, b_tan: PointUVW, scale_uv: f64) -> (r2::point::Point, i32) {
+    // Optimization: if B is within the safe region of the face, use it.
+    let max_save_uv_coord = 1.0 - FACE_CLIP_ERROR_UV_COORD;
+    if b.0.z > 0.0 {
+        let uv = r2::point::Point{x: b.0.x / b.0.z,  y: b.0.y / b.0.z };
+        if uv.x.abs().max(uv.y.abs()) < max_save_uv_coord {
+            return (uv, 0)
+        } 
+    }
+
+    let mut uv = &(scaled_n.exit_point(scaled_n.exit_axis())) * scale_uv;
+    let p: PointUVW = Point(r3::vector::Vector{x: uv.x, y: uv.y, z: 1.0});
+
+    // Determine if the exit point B' is contained within the segment. We do this
+	// by computing the dot products with two inward-facing tangent vectors at A
+	// and B. If either dot product is negative, we say that B' is on the "wrong
+	// side" of that point. As the point B' moves around the great circle AB past
+	// the segment endpoint B, it is initially on the wrong side of B only; as it
+	// moves further it is on the wrong side of both endpoints; and then it is on
+	// the wrong side of A only. If the exit point B' is on the wrong side of
+	// either endpoint, we can't use it; instead the segment is clipped at the
+	// original endpoint B.
+	//
+	// We reject the segment if the sum of the scores of the two endpoints is 3
+	// or more. Here is what that rule encodes:
+	//  - If B' is on the wrong side of A, then the other clipped endpoint A'
+	//    must be in the interior of AB (otherwise AB' would go the wrong way
+	//    around the circle). There is a similar rule for A'.
+	//  - If B' is on the wrong side of either endpoint (and therefore we must
+	//    use the original endpoint B instead), then it must be possible to
+	//    project B onto this face (i.e., its w-coordinate must be positive).
+	//    This rule is only necessary to handle certain zero-length edges (A=B).
+    let mut score = 0;
+    if (p.0 - a.0).dot(&a_tan.0) < 0.0 {
+        score = 2; // B' is on wrong side of A.
+    } else if (p.0 - b.0).dot(&b_tan.0) < 0.0{
+        score = 1; // B' is on wrong side of B.
+    }
+
+    if score > 0 { // B' is not in the interior of AB.
+        if b.0.z <= 0.0 {
+            score = 3; // B cannot be projected onto this face.
+        } else {
+            let v = b.0;
+            uv = r2::point::Point{x: v.x / v.z, y: v.y / v.z}
+        }
+    }
+
+    (uv, score)
+}
+
+// update_endpoint returns the interval with the specified endpoint updated to
+// the given value. If the value lies beyond the opposite endpoint, nothing is
+// changed and false is returned
+fn update_endpoint(mut bound: r1::interval::Interval, high_endpoint: bool, value: f64) -> (r1::interval::Interval, bool) {
+    if !high_endpoint {
+        if bound.hi < value {
+            return (bound, false)
+        }
+        if bound.lo < value {
+            bound.lo = value
+        }
+        return (bound, true)
+    }
+
+    if bound.lo > value {
+        return (bound, false)
+    }
+    if bound.hi > value {
+        bound.hi = value
+    }
+    (bound, true)
+}
+
+// clip_bound_axis returns the clipped versions of the bounding intervals for the given
+// axes for the line segment from (a0,a1) to (b0,b1) so that neither extends beyond the
+// given clip interval. negSlope is a precomputed helper variable that indicates which
+// diagonal of the bounding box is spanned by AB; it is false if AB has positive slope,
+// and true if AB has negative slope. If the clipping interval doesn't overlap the bounds,
+// false is returned
+fn clip_bound_axis(a0: f64, b0: f64, mut bound0: r1::interval::Interval, a1: f64, b1: f64, bound1: r1::interval::Interval, neg_slope: bool, clip: r1::interval::Interval) 
+    -> (r1::interval::Interval, r1::interval::Interval, bool) {
+
+    if bound0.lo < clip.lo {
+        // If the upper bound is below the clips lower bound, there is nothing to do.
+        if bound0.hi < clip.lo {
+            return (bound0, bound1, false)
+        }
+        // narrow the intervals lower bound to the clip bound
+        bound0.lo = clip.lo;
+        let (bound1, updated) = update_endpoint(bound1, neg_slope, interpolate(clip.lo, a0, b0, a1, b1));
+        if !updated {
+            return (bound0, bound1, false) 
+        }
+    }
+
+    if bound0.hi > clip.hi {
+        // If the lower bound is above the clips upper bound, there is nothing to do.
+        if bound0.lo > clip.hi {
+            return (bound0, bound1, false)
+        }
+        // narrow the intervals upper bound to the clip bound.
+        bound0.hi = clip.hi;
+        let (bound1, updated) = update_endpoint(bound1, !neg_slope, interpolate(clip.hi, a0, b0, a1, b1));
+        if !updated {
+            return (bound0, bound1, false)
+        }
+    }
+    return (bound0, bound1, true)
+}
+
+// edge_intersects_rect reports whether the edge defined by AB intersects the
+// given closed rectangle to within the error bound.
+#[allow(dead_code)]
+fn edge_intersects_rec(a: r2::point::Point, b: r2::point::Point, r: &r2::rect::Rect) -> bool {
+    // First check whether the bounds of a Rect around AB intersects the given rect.
+    if !r.intersects(&(r2::rect::Rect::from_points(&[a,b]))) {
+        return false
+    }
+
+    // Otherwise AB intersects the rect if and only if all four vertices of rect
+	// do not lie on the same side of the extended line AB. We test this by finding
+	// the two vertices of rect with minimum and maximum projections onto the normal
+	// of AB, and computing their dot products with the edge normal.
+    let n = (b - a).ortho();
+    let (mut i, mut j):(isize, isize) = (0,0);
+    if n.x >= 0.0 {
+        i = 1;
+    }
+    if n.y >= 0.0 {
+        j = 1;
+    }
+    let max = n.dot(&(r.vertex_ij(i,j) - a));
+    let min = n.dot(&(r.vertex_ij(1-i,1-j) - a));
+
+    return (max >= 0.0) && (min <= 0.0)
+}
+
+// clippedEdgeBound returns the bounding rectangle of the portion of the edge defined
+// by AB intersected by clip. The resulting bound may be empty. This is a convenience
+// function built on top of clipEdgeBound.
+#[allow(dead_code)]
+fn clipped_edge_bound(a: r2::point::Point, b: r2::point::Point, clip: r2::rect::Rect) -> r2::rect::Rect  {
+    let bound = r2::rect::Rect::from_points(&[a,b]);
+    let (b1, intersects) = clip_edge_bound(a, b, clip, bound);
+    if intersects {
+        b1
+    } else {
+        r2::rect::EMPTY
+    }
+}
+
+// clip_edge_bound clips an edge AB to sequence of rectangles efficiently.
+// It represents the clipped edges by their bounding boxes rather than as a pair of
+// endpoints. Specifically, let A'B' be some portion of an edge AB, and let bound be
+// a tight bound of A'B'. This function returns the bound that is a tight bound
+// of A'B' intersected with a given rectangle. If A'B' does not intersect clip,
+// it returns false and the original bound.
+#[allow(dead_code)]
+fn clip_edge_bound(a: r2::point::Point, b: r2::point::Point, clip: r2::rect::Rect, bound: r2::rect::Rect) -> (r2::rect::Rect, bool) {
+	// negSlope indicates which diagonal of the bounding box is spanned by AB: it
+	// is false if AB has positive slope, and true if AB has negative slope. This is
+	// used to determine which interval endpoints need to be updated each time
+	// the edge is clipped
+    let neg_slope = (a.x > b.x) != (a.y > b.y);
+    let (b0_x, b0_y, up1) = clip_bound_axis(a.x, b.x, bound.x, a.y, b.y, bound.y, neg_slope, clip.x);
+    if !up1 {
+        return (bound, false)
+    }
+    let (b1_x, b1_y, up2) = clip_bound_axis(a.x, b.x, bound.x, a.y, b.y, bound.y, neg_slope, clip.x);
+    if !up2 {
+        return (r2::rect::Rect{x: b0_x, y: b0_y}, false)
+    }
+    return (r2::rect::Rect{x: b1_x, y: b1_y}, true)
+}
+
+// interpolate returns a value with the same combination of a1 and b1 as the
+// given value x is of a and b. This function makes the following guarantees:
+//  - If x == a, then x1 = a1 (exactly).
+//  - If x == b, then x1 = b1 (exactly).
+//  - If a <= x <= b, then a1 <= x1 <= b1 (even if a1 == b1).
+// This requires a != b.
+fn interpolate(x: f64, a: f64, b: f64, a1: f64, b1: f64) -> f64 {
+    if (a-x).abs() <= (b-x).abs() {
+        return a1 + (b1-a1) * (x-a) / (b-a)
+    }
+    b1 + (a1-b1) * (x-b) / (a-b)
+}
+
+// FaceSegment represents an edge AB clipped to an S2 cube face. It is
+// represented by a face index and a pair of (u,v) coordinates.
+#[derive(Clone,Copy,PartialEq,Debug)]
+pub struct FaceSegment {
+    pub face: u8,
+    pub a: r2::point::Point,
+    pub b: r2::point::Point,
+}
+
+// face_segments subdivides the given edge AB at every point where it crosses the
+// boundary between two S2 cube faces and returns the corresponding FaceSegments.
+// The segments are returned in order from A toward B. The input points must be
+// unit length.
+//
+// This function guarantees that the returned segments form a continuous path
+// from A to B, and that all vertices are within faceClipErrorUVDist of the
+// line AB. All vertices lie within the [-1,1]x[-1,1] cube face rectangles.
+// The results are consistent with Sign, i.e. the edge is well-defined even its
+// endpoints are antipodal.
+// TODO(roberts): Extend the implementation of PointCross so that this is true.
+pub fn face_segments(a: Point, b: Point) -> Vec<FaceSegment> {
+    // Fast path: both endpoints are on the same face
+    let (a_face, a_x, a_y) = stuv::xyz_to_face_uv(&a.0);
+    let (b_face, b_x, b_y) = stuv::xyz_to_face_uv(&b.0);
+
+    if a_face == b_face {
+        return vec![
+            FaceSegment {
+                face: a_face,
+                a: r2::point::Point{ x: a_x, y: a_y },
+                b: r2::point::Point{ x: b_x, y: b_y },
+            }
+        ]
+    }
+
+	// Starting at A, we follow AB from face to face until we reach the face
+	// containing B. The following code is designed to ensure that we always
+	// reach B, even in the presence of numerical errors.
+	//
+	// First we compute the normal to the plane containing A and B. This normal
+	// becomes the ultimate definition of the line AB; it is used to resolve all
+	// questions regarding where exactly the line goes. Unfortunately due to
+	// numerical errors, the line may not quite intersect the faces containing
+	// the original endpoints. We handle this by moving A and/or B slightly if
+	// necessary so that they are on faces intersected by the line AB.
+    let mut segment = FaceSegment {
+        face: a_face,
+        a: r2::point::Point{ x: a_x, y: a_y },
+        b: r2::point::Point{ x: b_x, y: b_y },
+    };
+
+    #[allow(unused)]
+    let ab = a.cross(&b);
+
+    let (a_face, segment_a) = move_origin_to_valid_face(a_face, a, ab, segment.a);
+    let (b_face, segment_b) = move_origin_to_valid_face(b_face, b, ab * -1.0, segment.b);
+
+    segment = FaceSegment{
+        face: a_face,
+        a: segment_a,
+        b: segment_b,
+    };
+
+    let mut segments = Vec::new();
+    let b_saved = segment_b;
+    let mut face = a_face;
+    while face != b_face {
+        // Complete the current segment by finding the point where AB
+		// exits the current face
+
+        let n: PointUVW = stuv::face_xyz_to_uvw(face, &ab);
+        let exit_axis = n.exit_axis();
+        segment.b = n.exit_point(exit_axis);
+        segments.push(segment.clone());
+        
+        // Compute the next face intersected by AB, and translate the exit
+		// point of the current segment into the (u,v) coordinates of the
+		// next face. This becomes the first point of the next segment. 
+        let exit_xyz = stuv::face_uv_to_xyz(face, segment.b.x, segment.b.y);
+        face = next_face(face, segment.b, exit_axis, n, b_face);
+        let exit_uvw = stuv::face_xyz_to_uvw(face, &Point(exit_xyz));
+        segment.face = face;
+        segment.a = r2::point::Point{x: exit_uvw.0.x, y: exit_uvw.0.y};
+    }
+    segment.b = b_saved;
+    segments.push(segment);
+    segments
+}
+
+
+// moveOriginToValidFace updates the origin point to a valid face if necessary.
+// Given a line segment AB whose origin A has been projected onto a given cube
+// face, determine whether it is necessary to project A onto a different face
+// instead. This can happen because the normal of the line AB is not computed
+// exactly, so that the line AB (defined as the set of points perpendicular to
+// the normal) may not intersect the cube face containing A. Even if it does
+// intersect the face, the exit point of the line from that face may be on
+// the wrong side of A (i.e., in the direction away from B). If this happens,
+// we reproject A onto the adjacent face where the line AB approaches A most
+// closely. This moves the origin by a small amount, but never more than the
+// error tolerances.
+fn move_origin_to_valid_face(mut face: u8, a: Point, ab: Point, mut a_uv: r2::point::Point) -> (u8, r2::point::Point) {
+    // Fast path: if the origin is sufficiently far inside the face, it is
+	// always safe to use it.
+    let max_save_uv_coord = 1.0 - FACE_CLIP_ERROR_UV_COORD;
+    if a_uv.x.abs().max(a_uv.y.abs()) <= max_save_uv_coord {
+        return (face, a_uv)
+    }
+    
+    // Otherwise check whether the normal AB even intersects this face
+    let n: PointUVW = stuv::face_xyz_to_uvw(face, &ab);
+    if n.intersects_face() {
+		// Check whether the point where the line AB exits this face is on the
+		// wrong side of A (by more than the acceptable error tolerance).
+        let uv = n.exit_point(n.exit_axis());
+        let exit = stuv::face_uv_to_xyz(face, uv.x, uv.y);
+        let a_tan = ab.normalize().cross(&a);
+
+		// We can use the given face
+        if (exit - a.0).dot(&a_tan.0) >= -FACE_CLIP_ERROR_RADIANS {
+            return (face, a_uv)
+        }
+    }
+
+    // Otherwise we reproject A to the nearest adjacent face. (If line AB does
+	// not pass through a given face, it must pass through all adjacent faces.)
+    let mut dir: u8 = 0;
+    if a_uv.x.abs() >= a_uv.y.abs(){
+        // U-axis
+        if a_uv.x > 0.0 {
+            dir =1;
+        }
+        face = stuv::uvw_face(face, 0, dir);
+    } else {
+        // V-axis
+        if a_uv.y > 0.0 {
+            dir = 1;
+        }
+        face = stuv::uvw_face(face, 1, dir);
+    }
+
+    let (a_uv_x, a_uv_y) = stuv::valid_face_xyz_to_uv(face, &a.0);
+    a_uv.x = a_uv_x;
+    a_uv.y = a_uv_y;
+    a_uv.x = -1.0f64.max(1.0f64.min(a_uv.x));
+    a_uv.y = -1.0f64.max(1.0f64.min(a_uv.y));
+    (face, a_uv)
+}
+
+// nextFace returns the next face that should be visited by FaceSegments, given that
+// we have just visited face and we are following the line AB (represented
+// by its normal N in the (u,v,w) coordinates of that face). The other
+// arguments include the point where AB exits face, the corresponding
+// exit axis, and the target face containing the destination point B
+fn next_face(face: u8, exit: r2::point::Point, axis: Axis, n: PointUVW, target_face: u8) -> u8 {
+    // this bit is to work around C++ cleverly casting bools to ints for you.
+    let mut exit_a = exit.x;
+    let mut exit_1minus_a = exit.y;
+
+    if axis == Axis::AxisV {
+        exit_a = exit.y;
+        exit_1minus_a = exit.x;
+    }
+
+    let exit_a_pos = if exit_a > 0.0 {
+        1
+    } else {
+        0
+    };
+
+    let exit_1minus_a_pos = if exit_1minus_a > 0.0 {
+        1
+    } else {
+        0
+    };
+
+    // We return the face that is adjacent to the exit point along the given
+	// axis. If line AB exits *exactly* through a corner of the face, there are
+	// two possible next faces. If one is the target face containing B, then
+	// we guarantee that we advance to that face directly.
+	//
+	// The three conditions below check that (1) AB exits approximately through
+	// a corner, (2) the adjacent face along the non-exit axis is the target
+	// face, and (3) AB exits *exactly* through the corner. (The sumEqual
+	// code checks whether the dot product of (u,v,1) and n is exactly zero.)
+    if exit_1minus_a.abs() == 1.0 && stuv::uvw_face(face, 1-axis.value(), exit_1minus_a_pos) == target_face && sum_equal(exit.x*n.0.x, exit.y*n.0.y, -n.0.z) {
+        return target_face
+    }
+
+    // Otherwise return the face that is adjacent to the exit point in the
+	// direction of the exit axis
+    stuv::uvw_face(face, axis.value(), exit_a_pos)
+}
+
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use point::Point;
+    use r3;
+
+    #[test]
+    fn test_edge_clipping_intersects_face() {
+        /*
+		{pointUVW{r3.Vector{-3.88578e-16, -math.Sqrt(2.0 / 3.0), math.Sqrt(2.0 / 3.0)}}, true}
+        */
+        assert!((Point(r3::vector::Vector{x: 2.05335e-06, y: 3.91604e-22, z: 2.90553e-06}) as PointUVW).intersects_face() == false);
+        assert!((Point(r3::vector::Vector{x: -3.91604e-22, y: -2.05335e-06, z: -2.90553e-06}) as PointUVW).intersects_face() == false);
+        assert!((Point(r3::vector::Vector{x: 0.169258, y: -0.169258, z: 0.664013}) as PointUVW).intersects_face() == false);
+        assert!((Point(r3::vector::Vector{x: 0.169258, y: -0.169258, z: 0.664013}) as PointUVW).intersects_face() == false);
+        assert!((Point(r3::vector::Vector{x: (2.0_f64 / 3.0_f64).sqrt() , y: -(2.0_f64 / 3.0_f64).sqrt(), z: 3.88578e-16}) as PointUVW).intersects_face() == true);
+        assert!((Point(r3::vector::Vector{x: 3.88578e-16 , y: -(2.0_f64 / 3.0_f64).sqrt(), z: (2.0_f64 / 3.0_f64).sqrt()}) as PointUVW).intersects_face() == true);
+    }
+    
+    #[test]
+    fn test_edge_clipping_intersects_opposite_edges() {
+        assert!((Point(r3::vector::Vector{x: 0.169258, y: -0.169258, z: 0.664013}) as PointUVW).intersects_opposite_edges() == false);
+        assert!((Point(r3::vector::Vector{x: 0.169258, y: -0.169258, z: -0.664013}) as PointUVW).intersects_opposite_edges() == false);
+        assert!((Point(r3::vector::Vector{x: (4.0_f64 / 3.0_f64).sqrt(), y: 0_f64, z: -(4_f64 / 3_f64).sqrt()}) as PointUVW).intersects_opposite_edges() == true);
+        assert!((Point(r3::vector::Vector{x: (4.0_f64 / 3.0_f64).sqrt(), y: 0_f64, z: (4_f64 / 3_f64).sqrt()}) as PointUVW).intersects_opposite_edges() == true);
+        assert!((Point(r3::vector::Vector{x: -(2.0_f64 / 3.0_f64).sqrt(), y: -(2.0_f64 / 3.0_f64).sqrt(), z: 1.66533453694e-16}) as PointUVW).intersects_opposite_edges() == false);
+        assert!((Point(r3::vector::Vector{x: (2.0_f64 / 3.0_f64).sqrt(), y: (2.0_f64 / 3.0_f64).sqrt(), z: -1.66533453694e-16}) as PointUVW).intersects_opposite_edges() == false);
+    }
+
+    #[test]
+    fn test_edge_clipping_exit_point() {
+
+    }
+}

--- a/src/s2/mod.rs
+++ b/src/s2/mod.rs
@@ -15,5 +15,7 @@ pub mod edgeutil;
 pub mod metric;
 pub mod predicates;
 
+pub mod shape;
+
 #[cfg(test)]
 mod random;

--- a/src/s2/shape.rs
+++ b/src/s2/shape.rs
@@ -1,0 +1,251 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use r2::point::Point;
+use s2::point::Point as s2Point;
+use std::cmp::Ordering;
+
+// Edge represents a geodesic edge consisting of two vertices. Zero-length edges are
+// allowed, and can be used to represent points.
+
+pub struct Edge {
+	v0: Point, 
+	v1: Point
+}
+
+
+impl Eq for Edge {}
+
+impl Ord for Edge {
+	fn cmp(&self, other: &Edge) -> Ordering {
+		let v0cmp = self.v0.cmp(&other.v0);
+		if v0cmp != Ordering::Equal {
+			v0cmp
+		} else {
+			self.v0.cmp(&other.v1)
+		}
+	}
+}
+
+impl PartialOrd for Edge {
+    fn partial_cmp(&self, other: &Edge) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Edge {
+    fn eq(&self, other: &Edge) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+
+// sortEdges sorts the slice of Edges in place.
+pub fn sort_edges(mut e: Vec<Edge>) {
+	e.sort()
+}
+
+// edges implements the Sort interface for slices of Edge.
+type Edges = Vec<Edge>;
+
+trait EdgesMethods {
+	fn less(&self, i: i64, j: i64) -> bool;
+}
+
+impl EdgesMethods for Edges {
+	fn less(&self, i: i64, j: i64) -> bool { self[i as usize].cmp(&self[j as usize]) == Ordering::Less }
+}
+
+// Shapeedge_id is a unique identifier for an Edge within an ShapeIndex,
+// consisting of a (shape_id, edge_id) pair.
+pub struct ShapeEdgeID {
+	shape_id: i32,
+	edge_id:  i32
+}
+
+impl ShapeEdgeID {
+	// Cmp compares the two Shapeedge_ids and returns
+	//
+	//   -1 if s <  other
+	//    0 if s == other
+	//   +1 if s >  other
+	//
+	// The two are compared first by shape id and then by edge id.
+	pub fn cmp(&self, other: ShapeEdgeID) -> i64 {
+		if self.shape_id < other.shape_id {
+			return -1
+		} else if self.shape_id > other.shape_id {
+			return 1
+		}
+
+		if self.edge_id < other.edge_id {
+			return -1
+		} else if self.edge_id > other.edge_id {
+			return 1
+		}
+		return 0
+	}
+}
+
+// ShapeEdge represents a Shapeedge_id with the two endpoints of that Edge.
+pub struct ShapeEdge {
+	id: ShapeEdgeID,
+	edge: Edge
+}
+
+// Chain represents a range of edge IDs corresponding to a chain of connected
+// edges, specified as a (start, length) pair. The chain is defined to consist of
+// edge IDs {start, start + 1, ..., start + length - 1}.
+pub struct Chain {
+	start: i64, 
+	length: i64
+}
+
+// ChainPosition represents the position of an edge within a given edge chain,
+// specified as a (chainID, offset) pair. Chains are numbered sequentially
+// starting from zero, and offsets are measured from the start of each chain.
+pub struct ChainPosition {
+	chain_id: i64, 
+	offset: i64
+}
+
+// A ReferencePoint consists of a point and a boolean indicating whether the point
+// is contained by a particular shape.
+pub struct ReferencePoint {
+	point: s2Point,
+	contained: bool
+}
+
+// OriginReferencePoint returns a ReferencePoint with the given value for
+// contained and the origin point. It should be used when all points or no
+// points are contained.
+pub fn origin_reference_point(contained: bool) -> ReferencePoint {
+	ReferencePoint{point: s2Point::origin(), contained: contained}
+}
+
+// Shape represents polygonal geometry in a flexible way. It is organized as a
+// collection of edges that optionally defines an interior. All geometry
+// represented by a given Shape must have the same dimension, which means that
+// an Shape can represent either a set of points, a set of polylines, or a set
+// of polygons.
+//
+// Shape is defined as an interface in order to give clients control over the
+// underlying data representation. Sometimes an Shape does not have any data of
+// its own, but instead wraps some other type.
+//
+// Shape operations are typically defined on a ShapeIndex rather than
+// individual shapes. An ShapeIndex is simply a collection of Shapes,
+// possibly of different dimensions (e.g. 10 points and 3 polygons), organized
+// into a data structure for efficient edge access.
+//
+// The edges of a Shape are indexed by a contiguous range of edge IDs
+// starting at 0. The edges are further subdivided into chains, where each
+// chain consists of a sequence of edges connected end-to-end (a polyline).
+// For example, a Shape representing two polylines AB and CDE would have
+// three edges (AB, CD, DE) grouped into two chains: (AB) and (CD, DE).
+// Similarly, an Shape representing 5 points would have 5 chains consisting
+// of one edge each.
+//
+// Shape has methods that allow edges to be accessed either using the global
+// numbering (edge ID) or within a particular chain. The global numbering is
+// sufficient for most purposes, but the chain representation is useful for
+// certain algorithms such as intersection (see BooleanOperation).
+pub trait Shape {
+	// NumEdges returns the number of edges in this shape.
+	fn num_edges(&self) -> i64;
+
+	// Edge returns the edge for the given edge index.
+	fn edge(&self, i: i64) -> Edge;
+
+	// ReferencePoint returns an arbitrary reference point for the shape. (The
+	// containment boolean value must be false for shapes that do not have an interior.)
+	//
+	// This reference point may then be used to compute the containment of other
+	// points by counting edge crossings.
+	fn reference_point(&self) -> ReferencePoint;
+
+	// NumChains reports the number of contiguous edge chains in the shape.
+	// For example, a shape whose edges are [AB, BC, CD, AE, EF] would consist
+	// of two chains (AB,BC,CD and AE,EF). Every chain is assigned a chain Id
+	// numbered sequentially starting from zero.
+	//
+	// Note that it is always acceptable to implement this method by returning
+	// NumEdges, i.e. every chain consists of a single edge, but this may
+	// reduce the efficiency of some algorithms.
+	fn num_chains(&self) -> i64;
+
+	// Chain returns the range of edge IDs corresponding to the given edge chain.
+	// Edge chains must form contiguous, non-overlapping ranges that cover
+	// the entire range of edge IDs. This is spelled out more formally below:
+	//
+	//  0 <= i < NumChains()
+	//  Chain(i).length > 0, for all i
+	//  Chain(0).start == 0
+	//  Chain(i).start + Chain(i).length == Chain(i+1).start, for i < NumChains()-1
+	//  Chain(i).start + Chain(i).length == NumEdges(), for i == NumChains()-1
+	fn chain(&self, chain_id: i64) -> Chain;
+
+	// ChainEdgeReturns the edge at offset "offset" within edge chain "chainID".
+	// Equivalent to "shape.Edge(shape.Chain(chainID).start + offset)"
+	// but more efficient.
+	fn chain_edge(&self, chain_id: i64, offset: i64) -> Edge;
+
+	// ChainPosition finds the chain containing the given edge, and returns the
+	// position of that edge as a ChainPosition(chainID, offset) pair.
+	//
+	//  shape.Chain(pos.chainID).start + pos.offset == edge_id
+	//  shape.Chain(pos.chainID+1).start > edge_id
+	//
+	// where pos == shape.ChainPosition(edge_id).
+	fn chain_position(&self, edge_id: i64) -> ChainPosition;
+
+	// Dimension returns the dimension of the geometry represented by this shape,
+	// either 0, 1 or 2 for point, polyline and polygon geometry respectively.
+	//
+	//  0 - Point geometry. Each point is represented as a degenerate edge.
+	//
+	//  1 - Polyline geometry. Polyline edges may be degenerate. A shape may
+	//      represent any number of polylines. Polylines edges may intersect.
+	//
+	//  2 - Polygon geometry. Edges should be oriented such that the polygon
+	//      interior is always on the left. In theory the edges may be returned
+	//      in any order, but typically the edges are organized as a collection
+	//      of edge chains where each chain represents one polygon loop.
+	//      Polygons may have degeneracies (e.g., degenerate edges or sibling
+	//      pairs consisting of an edge and its corresponding reversed edge).
+	//      A polygon loop may also be full (containing all points on the
+	//      sphere); by convention this is represented as a chain with no edges.
+	//      (See laxPolygon for details.)
+	//
+	// This method allows degenerate geometry of different dimensions
+	// to be distinguished, e.g. it allows a point to be distinguished from a
+	// polyline or polygon that has been simplified to a single point.
+	fn dimension(&self) -> i64;
+
+	// IsEmpty reports whether the Shape contains no points. (Note that the full
+	// polygon is represented as a chain with zero edges.)
+	fn is_empty(&self) -> bool;
+
+	// IsFull reports whether the Shape contains all points on the sphere.
+	fn is_full(&self) -> bool;
+
+}
+
+// defaultShapeIsEmpty reports whether this shape contains no points.
+pub fn default_shape_is_empty(s: Box<Shape>) -> bool {
+	return s.num_edges() == 0 && (s.dimension() != 2 || s.num_chains() == 0)
+}
+
+// defaultShapeIsFull reports whether this shape contains all points on the sphere.
+pub fn default_shape_is_full(s: Box<Shape>) -> bool {
+	return s.num_edges() == 0 && s.dimension() == 2 && s.num_chains() > 0
+}


### PR DESCRIPTION
All but one test pass.

The test that doesn't pass is test_precise_round_trip(). This test converts a f64 vector to a precise vector, then converts it back to an f64 vector and normalizes it. The result should be equivalent to just normalizing the original f64 vector but it isn't.

The problem is that after conversion, the post-conversion normalized vector is accurate to one more decimal place than the pre-conversion normalized vector.

pre: 0.2672612419124244 post: 0.26726124191242434

Potential Research:
rust-lang/rust#24557
https://stackoverflow.com/questions/50361151/how-to-deal-with-inexact-floating-point-arithmetic-results-in-rust