### PR TITLE
Implement Display for CellID

### DIFF
--- a/src/s2/cap.rs
+++ b/src/s2/cap.rs
@@ -73,7 +73,8 @@ pub struct Cap {
     pub center: Point,
     pub radius: ChordAngle,
 }
-impl std::fmt::Debug for Cap {
+
+impl std::fmt::Display for Cap {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
@@ -81,6 +82,12 @@ impl std::fmt::Debug for Cap {
             self.center.0,
             Deg::from(self.radius()).0
         )
+    }
+}
+
+impl std::fmt::Debug for Cap {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 
@@ -519,17 +526,6 @@ impl std::ops::Add<Cap> for Cap {
     type Output = Cap;
     fn add(self, other: Cap) -> Self::Output {
         self + &other
-    }
-}
-
-impl std::fmt::Display for Cap {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "[center={:?}, radius={:?}]",
-            self.center.0,
-            Deg::from(self.radius()).0
-        )
     }
 }
 

--- a/src/s2/cellid.rs
+++ b/src/s2/cellid.rs
@@ -76,6 +76,12 @@ pub fn size_ij(level: u64) -> u64 {
     1 << (MAX_LEVEL - level)
 }
 
+impl std::fmt::Display for CellID {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.to_token())
+    }
+}
+
 impl CellID {
     /// from_pos_level returns a cell given its face in the range
     /// [0,5], the 61-bit Hilbert curve position pos within that face, and
@@ -970,9 +976,9 @@ pub fn find_lsb_set_nonzero64(bits: u64) -> u32 {
 pub mod tests {
     use super::*;
     use crate::consts::*;
-    use rand::Rng;
     use crate::s1;
     use crate::s2::random;
+    use rand::Rng;
 
     #[test]
     fn test_cellid_from_face() {

--- a/src/s2/random.rs
+++ b/src/s2/random.rs
@@ -1,11 +1,11 @@
 use cgmath;
 use std::f64::consts::PI;
 
-use rand;
-use rand::Rng;
 use crate::s2::cap::Cap;
 use crate::s2::cellid::*;
 use crate::s2::point::{self, Point};
+use rand;
+use rand::Rng;
 
 pub fn rng() -> rand::prng::XorShiftRng {
     use rand::prelude::*;

--- a/src/s2/region.rs
+++ b/src/s2/region.rs
@@ -546,10 +546,10 @@ impl RegionCoverer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::Rng;
     use crate::s2::cell::*;
     use crate::s2::metric::*;
     use crate::s2::random;
+    use rand::Rng;
     use std::f64::consts::PI;
 
     #[test]


### PR DESCRIPTION
I also replaced the duplicated fmt function in the Debug instance of Cap with the Display instance and ran cargo fmt.