### PR TITLE
Optional serde instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ rand = "0.5"
 cgmath = "0.16"
 libm = "0.1.3"
 bigdecimal = "*"
+serde = { version = "1.0", features = ["serde_derive"], optional = true }
 
 [profile.release]
 debug = 2
+
+[target.'cfg(feature="serde")'.dependencies]
+bigdecimal = { version = "*", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ extern crate cgmath;
 extern crate libm;
 extern crate rand;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 #[macro_use]
 mod consts;
 

--- a/src/r1/interval.rs
+++ b/src/r1/interval.rs
@@ -23,6 +23,7 @@ use crate::consts::EPSILON;
 /// Zero-length intervals (where Lo == Hi) represent single points.
 /// If Lo > Hi then the interval is empty.
 #[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Interval {
     /// lower bound of the interval
     pub lo: f64,

--- a/src/r2/point.rs
+++ b/src/r2/point.rs
@@ -21,6 +21,7 @@ use std::cmp::Ordering;
 
 /// Point represents a point in ℝ².
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point {
     /// x coordinate of the point
     pub x: f64,

--- a/src/r2/rect.rs
+++ b/src/r2/rect.rs
@@ -22,6 +22,7 @@ use crate::r2::point::Point;
 
 /// Rect represents a closed axis-aligned rectangle in the (x,y) plane.
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rect {
     /// x interval of the rect
     pub x: Interval,

--- a/src/r3/precisevector.rs
+++ b/src/r3/precisevector.rs
@@ -38,6 +38,7 @@ pub fn prec_float(f: f64) -> bigdecimal::BigDecimal {
 /// math. (e.g., methods that need divison like Normalize, or methods needing a
 /// square root operation such as Norm)
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PreciseVector {
     x: bigdecimal::BigDecimal,
     y: bigdecimal::BigDecimal,

--- a/src/r3/vector.rs
+++ b/src/r3/vector.rs
@@ -22,6 +22,7 @@ use crate::s1::angle::*;
 
 /// Vector represents a point in ℝ³.
 #[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Vector {
     pub x: f64,
     pub y: f64,
@@ -270,6 +271,7 @@ impl Vector {
 
 /// Axis enumerates the 3 axes of ℝ³.
 #[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Axis {
     X,
     Y,

--- a/src/s1/angle.rs
+++ b/src/s1/angle.rs
@@ -55,17 +55,23 @@ use std::f64::consts::PI;
 /// When testing for equality, you should allow for numerical errors (float64Eq)
 /// or convert to discrete E5/E6/E7 values first.
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Angle(f64);
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rad(pub f64);
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Deg(pub f64);
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct E5(pub i32);
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct E6(pub i32);
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct E7(pub i32);
 
 impl Angle {

--- a/src/s1/chordangle.rs
+++ b/src/s1/chordangle.rs
@@ -38,6 +38,7 @@ use crate::s1::angle::*;
 /// ChordAngles are represented by the squared chord length, which can
 /// range from 0 to 4. Positive infinity represents an infinite squared length.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ChordAngle(pub f64);
 
 /// NEGATIVE represents a chord angle smaller than the zero angle.

--- a/src/s1/interval.rs
+++ b/src/s1/interval.rs
@@ -31,6 +31,7 @@ use crate::r1;
 ///   - the empty interval, [π,-π].
 /// Treat the exported fields as read-only.
 #[derive(Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Interval {
     pub lo: f64,
     pub hi: f64,

--- a/src/s2/cap.rs
+++ b/src/s2/cap.rs
@@ -69,6 +69,7 @@ const CENTER_POINT: Point = Point(Vector {
 ///
 /// The zero value of Cap is an invalid cap. Use EmptyCap to get a valid empty cap.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Cap {
     pub center: Point,
     pub radius: ChordAngle,

--- a/src/s2/cell.rs
+++ b/src/s2/cell.rs
@@ -38,6 +38,7 @@ lazy_static! {
 /// it supports efficient containment and intersection tests. However, it is
 /// also a more expensive representation.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Cell {
     face: u8,
     level: u8,

--- a/src/s2/cellid.rs
+++ b/src/s2/cellid.rs
@@ -52,6 +52,7 @@ use crate::s2::stuv::*;
 /// representations. For cells that represent 2D regions rather than
 /// discrete point, it is better to use Cells.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CellID(pub u64);
 
 const FACE_BITS: u64 = 3;

--- a/src/s2/cellunion.rs
+++ b/src/s2/cellunion.rs
@@ -32,6 +32,7 @@ use crate::s2::region::Region;
 /// is contained by another, nor the four sibling CellIDs that are children of
 /// a single higher level CellID.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CellUnion(pub Vec<CellID>);
 
 impl CellUnion {

--- a/src/s2/edge_clipping.rs
+++ b/src/s2/edge_clipping.rs
@@ -214,6 +214,7 @@ fn sum_equal(u: f64, v: f64, w: f64) -> bool {
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 enum Axis {
     AxisU,
     AxisV,
@@ -581,6 +582,7 @@ fn interpolate(x: f64, a: f64, b: f64, a1: f64, b1: f64) -> f64 {
 /// FaceSegment represents an edge AB clipped to an S2 cube face. It is
 /// represented by a face index and a pair of (u,v) coordinates.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FaceSegment {
     pub face: u8,
     pub a: r2::point::Point,

--- a/src/s2/latlng.rs
+++ b/src/s2/latlng.rs
@@ -10,6 +10,7 @@ const NORTH_POLE_LAT: f64 = PI / 2.;
 const SOUTH_POLE_LAT: f64 = PI / -2.;
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LatLng {
     pub lat: Angle,
     pub lng: Angle,

--- a/src/s2/metric.rs
+++ b/src/s2/metric.rs
@@ -29,6 +29,7 @@ use crate::s2::cellid::MAX_LEVEL;
 // length or area on the unit sphere for cells at a given level. The minimum
 // and maximum bounds are valid for cells at all levels, but they may be
 // somewhat conservative for very large cells (e.g. face cells).
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Metric {
     // Dim is either 1 or 2, for a 1D or 2D metric respectively.
     dim: u8,

--- a/src/s2/point.rs
+++ b/src/s2/point.rs
@@ -18,6 +18,7 @@ use std::f64::consts::PI;
 /// Point represents a point on the unit sphere as a normalized 3D vector.
 /// Fields should be treated as read-only. Use one of the factory methods for creation.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point(pub Vector);
 
 impl std::ops::Add<Point> for Point {

--- a/src/s2/predicates.rs
+++ b/src/s2/predicates.rs
@@ -56,6 +56,7 @@ const MAX_DETERMINANT_ERROR: f64 = 1.8274 * DBL_EPSILON;
 const DET_ERROR_MULTIPLIER: f64 = 3.2321 * DBL_EPSILON;
 
 #[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Direction {
     Clockwise,
     Indeterminate,

--- a/src/s2/rect.rs
+++ b/src/s2/rect.rs
@@ -8,6 +8,7 @@ use crate::s2::edgeutil;
 use crate::s2::latlng::LatLng;
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rect {
     pub lat: r1::interval::Interval,
     pub lng: Interval,

--- a/src/s2/region.rs
+++ b/src/s2/region.rs
@@ -114,6 +114,7 @@ pub trait Region {
 /// algorithm may spend a lot of time subdividing cells all the way to leaf
 /// level to try to find contained cells.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RegionCoverer {
     /// the minimum cell level to be used.
     pub min_level: u8,
@@ -137,6 +138,7 @@ where
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct Candidate {
     cell: Cell,
     terminal: bool,


### PR DESCRIPTION
Adding optional serde instances for all types that seem intended for public use. I tried to err on the side of too many instances.

Tested with `cargo build --features="serde"`.