### PR TITLE
Implement `default()` for Angle, LatLng, Point and Vector

### DIFF
--- a/src/r3/vector.rs
+++ b/src/r3/vector.rs
@@ -21,7 +21,7 @@ use crate::consts::EPSILON;
 use crate::s1::angle::*;
 
 /// Vector represents a point in ℝ³.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Vector {
     pub x: f64,
@@ -292,6 +292,11 @@ mod tests {
                 z: $z,
             }
         };
+    }
+
+    #[test]
+    fn test_vector_default() {
+        assert_eq!(Vector::default(), V!(0., 0., 0.));
     }
 
     #[test]

--- a/src/s1/angle.rs
+++ b/src/s1/angle.rs
@@ -54,23 +54,23 @@ use std::f64::consts::PI;
 ///
 /// When testing for equality, you should allow for numerical errors (float64Eq)
 /// or convert to discrete E5/E6/E7 values first.
-#[derive(Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Angle(f64);
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rad(pub f64);
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Deg(pub f64);
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct E5(pub i32);
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct E6(pub i32);
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct E7(pub i32);
 
@@ -238,6 +238,12 @@ mod tests {
     #[test]
     fn test_empty_value() {
         assert_eq!(Deg::from(Angle(0.)).0, 0.);
+        assert_eq!(Angle::default().0, 0.);
+        assert_eq!(Rad::default().0, 0.);
+        assert_eq!(Deg::default().0, 0.);
+        assert_eq!(E5::default().0, 0);
+        assert_eq!(E6::default().0, 0);
+        assert_eq!(E7::default().0, 0);
     }
 
     #[test]

--- a/src/s2/latlng.rs
+++ b/src/s2/latlng.rs
@@ -9,7 +9,7 @@ use std::f64::consts::PI;
 const NORTH_POLE_LAT: f64 = PI / 2.;
 const SOUTH_POLE_LAT: f64 = PI / -2.;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LatLng {
     pub lat: Angle,
@@ -130,6 +130,12 @@ mod tests {
                 z: $z as f64,
             })
         };
+    }
+
+    #[test]
+    fn test_latlng_default() {
+        // Same as geo.s2.LatLng{} in Go.
+        assert_eq!(LatLng::default(), ll!(0.0, 0.0));
     }
 
     fn test_latlng_normalized_case(descr: &str, pos: LatLng, want: LatLng) {

--- a/src/s2/point.rs
+++ b/src/s2/point.rs
@@ -17,7 +17,7 @@ use std::f64::consts::PI;
 
 /// Point represents a point on the unit sphere as a normalized 3D vector.
 /// Fields should be treated as read-only. Use one of the factory methods for creation.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Default, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point(pub Vector);
 
@@ -457,6 +457,12 @@ mod tests {
 
     use crate::s2::stuv::st_to_uv;
     use std::f64::consts::PI;
+
+    #[test]
+    fn test_default() {
+        // Same as geo.s2.Point{} in Go.
+        assert_eq!(Point::default().0, Vector::default());
+    }
 
     #[test]
     fn test_origin_point() {


### PR DESCRIPTION
This will help to match the Go implementation of `Rect.Centroid()` that returns `Point{}` for empty rectangles. In Go, the default Point has coordinates `(0, 0, 0)` but it looks like the Rust port doesn’t supply a default yet.