### PR TITLE
Make `test_rect_centroid_full_range` more resilient to numeric noise

### DIFF
--- a/src/s2/rect.rs
+++ b/src/s2/rect.rs
@@ -1868,7 +1868,7 @@ mod tests {
         }
         let got = (r.centroid() - child0.centroid() - child1.centroid()).norm();
         assert!(
-            got <= 1e-15,
+            got <= EPSILON,
             "want ~0, got {:?}, r={:?}, child0={:?}, child1={:?}",
             got,
             r,


### PR DESCRIPTION
The equivalent Go unit test allow for numeric differences up to 1e-15, so I had ported this check without modification to Rust. However, in a in a clean repository checked out from the current main branch, I’ve seen the following test failure:

   > thread 's2::rect::tests::test_rect_centroid_full_range' panicked at 'want ~0, got 1.1957467920563633e-15, r=[lo[-27.6957262, -113.2939286], hi[90.0000000, 180.0000000]], child0=[lo[-27.6957262, -113.2939286], hi[90.0000000, 93.7187959]], child1=[lo[-27.6957262, 93.7187959], hi[90.0000000, 180.0000000]]', src/s2/rect.rs:2012:9

A difference of ~1.2e-15 is still very small and does not look like an actual bug. Therefore, let’s change this unittest to allow numeric differences up to `EPSILON`. This constant is defined as 1e-14, so the above delta would still be considered acceptable.