### PR TITLE
Fix clippy warnings for r2 and r3

### DIFF
--- a/src/r2/point.rs
+++ b/src/r2/point.rs
@@ -85,7 +85,7 @@ impl std::ops::Sub<Point> for Point {
     }
 }
 
-impl<'a, 'b> std::ops::Mul<&'b Point> for &'a Point {
+impl<'b> std::ops::Mul<&'b Point> for &Point {
     type Output = Point;
     /// returns the product between p and other.
     fn mul(self, other: &'b Point) -> Self::Output {
@@ -110,7 +110,7 @@ impl std::ops::Mul<Point> for Point {
     }
 }
 
-impl<'a> std::ops::Mul<f64> for &'a Point {
+impl std::ops::Mul<f64> for &Point {
     type Output = Point;
     /// returns the scalar product of p and other.
     fn mul(self, other: f64) -> Self::Output {

--- a/src/r3/precisevector.rs
+++ b/src/r3/precisevector.rs
@@ -50,12 +50,12 @@ impl From<r3::vector::Vector> for PreciseVector {
     }
 }
 
-impl Into<r3::vector::Vector> for PreciseVector {
-    fn into(self) -> r3::vector::Vector {
+impl From<PreciseVector> for r3::vector::Vector {
+    fn from(val: PreciseVector) -> Self {
         // The accuracy flag is ignored on these conversions back to float64.
-        let x = self.x.to_f64().unwrap();
-        let y = self.y.to_f64().unwrap();
-        let z = self.z.to_f64().unwrap();
+        let x = val.x.to_f64().unwrap();
+        let y = val.y.to_f64().unwrap();
+        let z = val.z.to_f64().unwrap();
         r3::vector::Vector { x, y, z }.normalize()
     }
 }
@@ -139,16 +139,16 @@ impl PreciseVector {
     pub fn dot(&self, ov: PreciseVector) -> bigdecimal::BigDecimal {
         let a = self.clone();
         let b = ov.clone();
-        return (a.x * b.x) + (a.y * b.y) + (a.z * b.z);
+        (a.x * b.x) + (a.y * b.y) + (a.z * b.z)
     }
 
     /// cross returns the standard cross product of v and ov.
     pub fn cross(&self, ov: PreciseVector) -> PreciseVector {
-        return PreciseVector {
+        PreciseVector {
             x: (&self.y * &ov.z) - (&self.z * &ov.y),
             y: (&self.z * &ov.x) - (&self.x * &ov.z),
             z: (&self.x * &ov.y) - (&self.y * &ov.x),
-        };
+        }
     }
 
     /// largest_component returns the axis that represents the largest component in this vector.
@@ -160,12 +160,10 @@ impl PreciseVector {
             } else {
                 r3::vector::Axis::Z
             }
+        } else if a.y > a.z {
+            r3::vector::Axis::Y
         } else {
-            if a.y > a.z {
-                r3::vector::Axis::Y
-            } else {
-                r3::vector::Axis::Z
-            }
+            r3::vector::Axis::Z
         }
     }
 
@@ -178,12 +176,10 @@ impl PreciseVector {
             } else {
                 r3::vector::Axis::Z
             }
+        } else if t.y < t.z {
+            r3::vector::Axis::Y
         } else {
-            if t.y < t.z {
-                r3::vector::Axis::Y
-            } else {
-                r3::vector::Axis::Z
-            }
+            r3::vector::Axis::Z
         }
     }
 }

--- a/src/r3/vector.rs
+++ b/src/r3/vector.rs
@@ -41,7 +41,7 @@ impl std::ops::Add<Vector> for Vector {
         &self + &other
     }
 }
-impl<'a, 'b> std::ops::Add<&'b Vector> for &'a Vector {
+impl<'b> std::ops::Add<&'b Vector> for &Vector {
     type Output = Vector;
     /// add returns the standard vector sum of v and ov.
     fn add(self, other: &'b Vector) -> Self::Output {
@@ -60,7 +60,7 @@ impl std::ops::Sub<Vector> for Vector {
         &self - &other
     }
 }
-impl<'a, 'b> std::ops::Sub<&'b Vector> for &'a Vector {
+impl<'b> std::ops::Sub<&'b Vector> for &Vector {
     type Output = Vector;
     fn sub(self, other: &'b Vector) -> Self::Output {
         Vector {
@@ -77,7 +77,7 @@ impl std::ops::Mul<Vector> for Vector {
         &self * &other
     }
 }
-impl<'a, 'b> std::ops::Mul<&'a Vector> for &'b Vector {
+impl<'a> std::ops::Mul<&'a Vector> for &Vector {
     type Output = Vector;
     fn mul(self, other: &'a Vector) -> Self::Output {
         Vector {
@@ -88,7 +88,7 @@ impl<'a, 'b> std::ops::Mul<&'a Vector> for &'b Vector {
     }
 }
 
-impl<'a> std::ops::Mul<f64> for &'a Vector {
+impl std::ops::Mul<f64> for &Vector {
     type Output = Vector;
     /// mul returns the standard scalar product of v and m.
     fn mul(self, m: f64) -> Self::Output {
@@ -241,12 +241,10 @@ impl Vector {
             } else {
                 Axis::Z
             }
+        } else if a.y > a.z {
+            Axis::Y
         } else {
-            if a.y > a.z {
-                Axis::Y
-            } else {
-                Axis::Z
-            }
+            Axis::Z
         }
     }
 
@@ -259,12 +257,10 @@ impl Vector {
             } else {
                 Axis::Z
             }
+        } else if t.y < t.z {
+            Axis::Y
         } else {
-            if t.y < t.z {
-                Axis::Y
-            } else {
-                Axis::Z
-            }
+            Axis::Z
         }
     }
 }


### PR DESCRIPTION
Change auto-generated by `cargo clippy --fix`. Manually removed some auto-generated changes to operators, which caused endless recursions.