### PR TITLE
Remove legacy numeric constants

### DIFF
--- a/src/r2/point.rs
+++ b/src/r2/point.rs
@@ -210,7 +210,7 @@ mod tests {
         assert_f64_eq!(2., P!(1., 3f64.sqrt()).norm());
         assert_f64_eq!(29. * 2., P!(29., 29. * 3f64.sqrt()).norm());
         assert_f64_eq!(1e15, P!(1., 1e15).norm());
-        assert_f64_eq!(std::f64::MAX, P!(1e14, std::f64::MAX - 1.).norm());
+        assert_f64_eq!(f64::MAX, P!(1e14, f64::MAX - 1.).norm());
     }
 
     fn test_normalize(p1: Point, p2: Point) {
@@ -228,6 +228,6 @@ mod tests {
         test_normalize(P!(7., 7. * 3f64.sqrt()), P!(0.5, 3f64.sqrt() / 2.));
         test_normalize(P!(1e21, 1e21 * 3f64.sqrt()), P!(0.5, 3f64.sqrt() / 2.));
         test_normalize(P!(1., 1e16), P!(0., 1.));
-        test_normalize(P!(1e4, std::f64::MAX - 1.), P!(0., 1.));
+        test_normalize(P!(1e4, f64::MAX - 1.), P!(0., 1.));
     }
 }

--- a/src/s1/angle.rs
+++ b/src/s1/angle.rs
@@ -87,7 +87,7 @@ impl Angle {
 
     /// inf returns an angle larger than any finite angle.
     pub fn inf() -> Self {
-        Angle(std::f64::INFINITY)
+        Angle(f64::INFINITY)
     }
 
     /// is_infinite reports whether this Angle is infinite.

--- a/src/s1/chordangle.rs
+++ b/src/s1/chordangle.rs
@@ -166,7 +166,7 @@ impl ChordAngle {
     /// inf returns a chord angle larger than any finite chord angle.
     /// The only valid operations on an InfChordAngle are comparisons and Angle conversions.
     pub fn inf() -> Self {
-        ChordAngle(std::f64::INFINITY)
+        ChordAngle(f64::INFINITY)
     }
 
     /// is_infinite reports whether this ChordAngle is infinite.

--- a/src/s2/cellid.rs
+++ b/src/s2/cellid.rs
@@ -17,7 +17,6 @@ limitations under the License.
 
 use std;
 use std::iter::*;
-use std::u64;
 
 use crate::consts::clamp;
 use crate::r1::interval::Interval;
@@ -107,7 +106,7 @@ impl CellID {
         j = clamp(j, -1i32, MAX_SIZE_I32);
 
         const SCALE: f64 = 1.0 / (MAX_SIZE as f64);
-        const LIMIT: f64 = 1f64 + std::f64::EPSILON;
+        const LIMIT: f64 = 1f64 + f64::EPSILON;
 
         let u = clamp(
             SCALE * (2. * f64::from(i) + 1. - MAX_SIZE_F64),

--- a/src/s2/stuv.rs
+++ b/src/s2/stuv.rs
@@ -249,7 +249,6 @@ mod tests {
     use super::*;
     use crate::r3::vector::Axis;
     use crate::s2::random;
-    use std;
 
     #[test]
     fn st_uv() {
@@ -266,7 +265,7 @@ mod tests {
                 let angle = face_uv_to_xyz(face, x, -1.)
                     .cross(&face_uv_to_xyz(face, x, 1.))
                     .angle(&unorm(face, x));
-                assert!(angle.rad() < std::f64::EPSILON);
+                assert!(angle.rad() < f64::EPSILON);
 
                 x += step;
                 if x > 1. {
@@ -318,8 +317,8 @@ mod tests {
 
     fn test_face_xyz_to_uv_case(face: u8, point: &Point, expected: (f64, f64, bool)) {
         if let Some((u, v)) = face_xyz_to_uv(face, point) {
-            assert!((u - expected.0) <= std::f64::EPSILON);
-            assert!((v - expected.1) <= std::f64::EPSILON);
+            assert!((u - expected.0) <= f64::EPSILON);
+            assert!((v - expected.1) <= f64::EPSILON);
             assert_eq!(true, expected.2);
         } else {
             assert_eq!(false, expected.2);
@@ -450,7 +449,7 @@ mod tests {
 
             {
                 let face_random = rng.gen_range(0..NUM_FACES);
-                let mask = (std::u64::MAX << (MAX_LEVEL - level)) & (MAX_SITI - 1);
+                let mask = (u64::MAX << (MAX_LEVEL - level)) & (MAX_SITI - 1);
                 let si_random = rng.gen_range(0..MAX_SITI) & mask;
                 let ti_random = rng.gen_range(0..MAX_SITI) & mask;
 


### PR DESCRIPTION
Fixes this clippy warning:
https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#legacy_numeric_constants