### PR TITLE
Suppress warning about ignored doctest that isn’t actually a test

### DIFF
--- a/src/s2/cap.rs
+++ b/src/s2/cap.rs
@@ -60,7 +60,7 @@ const CENTER_POINT: Point = Point(Vector {
 /// radius (r), the maximum chord length from the cap's center (d), and the
 /// radius of cap's base (a).
 ///
-/// ```ignore
+/// ```text
 ///     h = 1 - cos(r)
 ///       = 2 * sin^2(r/2)
 ///   d^2 = 2 * h


### PR DESCRIPTION
Before this change, `cargo test` would warn about a doctest being ignored. After this change, `cargo test` does not treat this docstring (which actually a math expression) as a test case.