### PR TITLE
CellUnion: parity with upstream S2 (closes #76)

### DIFF
--- a/src/s2/cellid.rs
+++ b/src/s2/cellid.rs
@@ -67,7 +67,7 @@ const MAX_SIZE_F64: f64 = MAX_SIZE as f64;
 const LOOKUP_BITS: u64 = 4;
 const INVERT_MASK: u8 = 0x02;
 
-fn lsb_for_level(level: u64) -> u64 {
+pub(crate) fn lsb_for_level(level: u64) -> u64 {
     1 << (2 * (MAX_LEVEL - level))
 }
 

--- a/src/s2/cellunion.rs
+++ b/src/s2/cellunion.rs
@@ -246,10 +246,21 @@ impl CellUnion {
         Self::merge(&[a.clone(), b.clone()])
     }
 
-    /// Intersection of two normalized cell unions.
+    /// Intersection of two cell unions whose cell ID vectors are sorted in increasing order
+    /// (as for a [`CellUnion`] built from normalized input).
+    ///
+    /// This does not call [`normalize`](Self::normalize) on the result, matching upstream S2:
+    /// if both inputs are [`is_normalized`](Self::is_normalized), the result is normalized;
+    /// otherwise callers can normalize explicitly if they need a canonical representation.
+    ///
+    /// In debug builds, asserts that inputs are sorted and that the normalization invariant
+    /// above holds (mirroring `ABSL_DCHECK` in the C++ implementation).
     pub fn intersection(a: &Self, b: &Self) -> Self {
         let x = &a.0;
         let y = &b.0;
+        debug_assert!(x.is_sorted());
+        debug_assert!(y.is_sorted());
+        // Mirrors `S2CellUnion::GetIntersection` in google/s2geometry `s2cell_union.cc`.
         let mut cu = Vec::new();
         let mut i = 0usize;
         let mut j = 0usize;
@@ -286,17 +297,22 @@ impl CellUnion {
                 j += 1;
             }
         }
-        let mut out = CellUnion(cu);
-        out.normalize();
+        debug_assert!(cu.is_sorted());
+        let out = CellUnion(cu);
+        debug_assert!(out.is_normalized() || !a.is_normalized() || !b.is_normalized());
         out
     }
 
     /// Intersection of a cell union with a single cell ID.
+    ///
+    /// Does not normalize the result. If `x` is [`is_normalized`](Self::is_normalized), the
+    /// result is normalized (same contract as upstream S2). `id` must be valid (debug-asserted).
     pub fn intersection_with_cell_id(x: &Self, id: CellID) -> Self {
+        debug_assert!(id.is_valid(), "invalid id: {:?}", id);
         if x.contains_cellid(&id) {
-            let mut cu = CellUnion(vec![id]);
-            cu.normalize();
-            return cu;
+            let out = CellUnion(vec![id]);
+            debug_assert!(out.is_normalized() || !x.is_normalized());
+            return out;
         }
         let id_max = id.range_max();
         let start = lower_bound_cellids(&x.0, 0, x.0.len(), id.range_min());
@@ -306,18 +322,26 @@ impl CellUnion {
             cu.push(x.0[k]);
             k += 1;
         }
-        let mut out = CellUnion(cu);
-        out.normalize();
+        let out = CellUnion(cu);
+        debug_assert!(out.is_normalized() || !x.is_normalized());
         out
     }
 
-    /// Set difference `x - y` for normalized inputs.
+    /// Set difference `x - y`.
+    ///
+    /// Does not normalize the result. If `x` is [`is_normalized`](Self::is_normalized), the
+    /// result is normalized (same contract as upstream S2). Call [`normalize`](Self::normalize)
+    /// afterward if you need a canonical union regardless of input shape.
     pub fn difference(x: &Self, y: &Self) -> Self {
+        // TODO: This is approximately O(N*log(N)), but could probably
+        // use similar techniques as intersection() to be more efficient.
         let mut cu = Vec::new();
         for xid in &x.0 {
             cell_union_difference_internal(&mut cu, *xid, y);
         }
-        CellUnion(cu)
+        let out = CellUnion(cu);
+        debug_assert!(out.is_normalized() || !x.is_normalized());
+        out
     }
 
     /// Whether this union contains every cell ID of `other` (regions semantics).
@@ -457,9 +481,16 @@ fn lower_bound_cellids(cells: &[CellID], begin: usize, end: usize, id: CellID) -
 }
 
 fn are_siblings(a: CellID, b: CellID, c: CellID, d: CellID) -> bool {
+    // A necessary (but not sufficient) condition is that the XOR of the
+    // four cells must be zero.  This is also very fast to test.
     if a.0 ^ b.0 ^ c.0 != d.0 {
         return false;
     }
+
+    // Now we do a slightly more expensive but exact test.  First, compute a
+    // mask that blocks out the two bits that encode the child position of
+    // `id` with respect to its parent, then check that the other three
+    // children all agree with `mask`.
     let mut mask = d.lsb() << 1;
     mask = !(mask + (mask << 1));
     let id_masked = d.0 & mask;
@@ -470,13 +501,23 @@ fn are_siblings(a: CellID, b: CellID, c: CellID, d: CellID) -> bool {
 }
 
 fn cell_union_difference_internal(out: &mut Vec<CellID>, id: CellID, other: &CellUnion) {
+    // Mirrors `GetDifferenceInternal` in google/s2geometry `s2cell_union.cc`.
+    // Add the difference between `id` and `other` to `out`.
+    // If they intersect but the difference is non-empty, divide and conquer.
     if !other.intersects_cellid(&id) {
         out.push(id);
         return;
     }
     if !other.contains_cellid(&id) {
-        for child in &id.children() {
-            cell_union_difference_internal(out, *child, other);
+        let mut child = id.child_begin();
+        let mut i = 0;
+        loop {
+            cell_union_difference_internal(out, child, other);
+            if i == 3 {
+                break;
+            }
+            child = child.next();
+            i += 1;
         }
     }
 }
@@ -732,6 +773,45 @@ mod tests {
     }
 
     #[test]
+    fn test_cellunion_intersection_with_cell_id_parent_covers_multiple_cells() {
+        // `x` holds two children of `parent`; `x` does not contain the parent id as one cell,
+        // so we exercise the range scan path (not the `contains_cellid` fast path).
+        let parent = CellID::from_face(2).child_begin_at_level(5);
+        let ch = parent.children();
+        let mut x = CellUnion(vec![ch[0], ch[1]]);
+        x.normalize();
+        assert!(x.is_normalized());
+
+        let cap = CellUnion::intersection_with_cell_id(&x, parent);
+        assert_eq!(cap.0, vec![ch[0], ch[1]]);
+        assert!(cap.is_normalized());
+    }
+
+    #[test]
+    fn test_normalized_intersection_and_difference_remain_normalized() {
+        let a = CellID::from_face(0).child_begin_at_level(3);
+        let b = CellID::from_face(1).child_begin_at_level(3);
+        let mut ua = CellUnion(vec![a]);
+        let mut ub = CellUnion(vec![b]);
+        ua.normalize();
+        ub.normalize();
+
+        let inter = CellUnion::intersection(&ua, &ub);
+        assert!(inter.is_normalized());
+        assert!(inter.0.is_empty());
+
+        let p = CellID::from_face(4).child_begin_at_level(4);
+        let ch = p.children();
+        let mut ux = CellUnion(vec![p]);
+        let mut uy = CellUnion(vec![ch[0]]);
+        ux.normalize();
+        uy.normalize();
+        let diff = CellUnion::difference(&ux, &uy);
+        assert!(diff.is_normalized());
+        assert_eq!(diff.0.len(), 3);
+    }
+
+    #[test]
     fn test_cellunion_from_range_empties_and_full_sphere() {
         let id_begin = CellID::from_face(0).child_begin_at_level(MAX_LEVEL);
         assert!(CellUnion::from_range(id_begin, id_begin).0.is_empty());
@@ -830,16 +910,21 @@ mod tests {
         let ch = parent.children();
 
         let u_parent = CellUnion(vec![parent]);
+        // Four siblings are valid but not normalized; C++ likewise allows
+        // GetIntersection without normalizing the output when an input is not.
         let u_children = CellUnion(vec![ch[0], ch[1], ch[2], ch[3]]);
 
-        // Intersection of parent with its own children yields the four children,
-        // which normalize back to the parent.
+        // Intersection yields the four leaf cells (same as upstream before any
+        // second Normalize pass); collapsing to the parent requires normalize().
         let inter = CellUnion::intersection(&u_parent, &u_children);
-        assert_eq!(inter.0.len(), 1);
-        assert_eq!(inter.0[0], parent);
+        assert_eq!(inter.0.len(), 4);
         for c in &ch {
             assert!(inter.contains_cellid(c));
         }
+        let mut inter_norm = inter.clone();
+        inter_norm.normalize();
+        assert_eq!(inter_norm.0.len(), 1);
+        assert_eq!(inter_norm.0[0], parent);
 
         // Intersect with just two children.
         let u_two = CellUnion(vec![ch[0], ch[2]]);

--- a/src/s2/cellunion.rs
+++ b/src/s2/cellunion.rs
@@ -15,12 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::cmp::min;
+
 use crate::consts::search_lower_by;
 use crate::r3::vector::Vector;
+use crate::s1::Angle;
 use crate::s2::cap::Cap;
 use crate::s2::cell::Cell;
 use crate::s2::cellid::*;
-use crate::s2::metric::*;
+use crate::s2::metric::{AVG_AREAMETRIC, MIN_WIDTHMETRIC};
 use crate::s2::point::Point;
 use crate::s2::rect::Rect;
 use crate::s2::region::Region;
@@ -48,6 +51,18 @@ impl CellUnion {
             cur = cur.next().max_tile(&end);
         }
         CellUnion(v)
+    }
+
+    /// Returns a CellUnion that covers the entire sphere.
+    pub fn whole_sphere() -> Self {
+        CellUnion(vec![
+            CellID::from_face(0),
+            CellID::from_face(1),
+            CellID::from_face(2),
+            CellID::from_face(3),
+            CellID::from_face(4),
+            CellID::from_face(5),
+        ])
     }
 
     /// normalize normalizes the CellUnion.
@@ -185,6 +200,190 @@ impl CellUnion {
         }
         num_leaves
     }
+
+    /// Reports whether the cell IDs are valid, non-overlapping, and sorted in increasing order.
+    pub fn is_valid(&self) -> bool {
+        for i in 0..self.0.len() {
+            if !self.0[i].is_valid() {
+                return false;
+            }
+            if i > 0 && self.0[i - 1].range_max() >= self.0[i].range_min() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Reports whether the union is valid and no four cells share a common parent.
+    pub fn is_normalized(&self) -> bool {
+        for i in 0..self.0.len() {
+            if !self.0[i].is_valid() {
+                return false;
+            }
+            if i > 0 && self.0[i - 1].range_max() >= self.0[i].range_min() {
+                return false;
+            }
+            if i >= 3 && are_siblings(self.0[i - 3], self.0[i - 2], self.0[i - 1], self.0[i]) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Concatenates several unions and normalizes the result (Go: `CellUnionFromUnion`).
+    pub fn merge(unions: &[CellUnion]) -> CellUnion {
+        let mut v = Vec::new();
+        for u in unions {
+            v.extend_from_slice(&u.0);
+        }
+        let mut cu = CellUnion(v);
+        cu.normalize();
+        cu
+    }
+
+    /// Normalized union of two cell unions.
+    pub fn union(a: &Self, b: &Self) -> Self {
+        Self::merge(&[a.clone(), b.clone()])
+    }
+
+    /// Intersection of two normalized cell unions.
+    pub fn intersection(a: &Self, b: &Self) -> Self {
+        let x = &a.0;
+        let y = &b.0;
+        let mut cu = Vec::new();
+        let mut i = 0usize;
+        let mut j = 0usize;
+        while i < x.len() && j < y.len() {
+            let i_min = x[i].range_min();
+            let j_min = y[j].range_min();
+            if i_min > j_min {
+                if x[i] <= y[j].range_max() {
+                    cu.push(x[i]);
+                    i += 1;
+                } else {
+                    // Advance j to the first cell whose range could contain x[i].
+                    // lower_bound returns >= j+1 (>= 1), so j-1 is always valid.
+                    j = lower_bound_cellids(y, j + 1, y.len(), i_min);
+                    if x[i] <= y[j - 1].range_max() {
+                        j -= 1;
+                    }
+                }
+            } else if j_min > i_min {
+                if y[j] <= x[i].range_max() {
+                    cu.push(y[j]);
+                    j += 1;
+                } else {
+                    i = lower_bound_cellids(x, i + 1, x.len(), j_min);
+                    if y[j] <= x[i - 1].range_max() {
+                        i -= 1;
+                    }
+                }
+            } else if x[i] < y[j] {
+                cu.push(x[i]);
+                i += 1;
+            } else {
+                cu.push(y[j]);
+                j += 1;
+            }
+        }
+        let mut out = CellUnion(cu);
+        out.normalize();
+        out
+    }
+
+    /// Intersection of a cell union with a single cell ID.
+    pub fn intersection_with_cell_id(x: &Self, id: CellID) -> Self {
+        if x.contains_cellid(&id) {
+            let mut cu = CellUnion(vec![id]);
+            cu.normalize();
+            return cu;
+        }
+        let id_max = id.range_max();
+        let start = lower_bound_cellids(&x.0, 0, x.0.len(), id.range_min());
+        let mut cu = Vec::new();
+        let mut k = start;
+        while k < x.0.len() && x.0[k] <= id_max {
+            cu.push(x.0[k]);
+            k += 1;
+        }
+        let mut out = CellUnion(cu);
+        out.normalize();
+        out
+    }
+
+    /// Set difference `x - y` for normalized inputs.
+    pub fn difference(x: &Self, y: &Self) -> Self {
+        let mut cu = Vec::new();
+        for xid in &x.0 {
+            cell_union_difference_internal(&mut cu, *xid, y);
+        }
+        CellUnion(cu)
+    }
+
+    /// Whether this union contains every cell ID of `other` (regions semantics).
+    pub fn contains_cell_union(&self, other: &Self) -> bool {
+        other.0.iter().all(|id| self.contains_cellid(id))
+    }
+
+    /// Whether this union intersects any cell ID of `other`.
+    pub fn intersects_cell_union(&self, other: &Self) -> bool {
+        self.0.iter().any(|id| other.intersects_cellid(id))
+    }
+
+    /// Whether the union contains `p` (point containment uses the containing leaf cell).
+    pub fn contains_point(&self, p: &Point) -> bool {
+        self.contains_cellid(&CellID::from(p))
+    }
+
+    /// Expands the union by adding a rim of cells at `expand_level` around its boundary.
+    pub fn expand_at_level(&mut self, expand_level: u64) {
+        let level_lsb = lsb_for_level(expand_level);
+        let mut output: Vec<CellID> = Vec::new();
+        let mut i = self.0.len();
+        while i > 0 {
+            i -= 1;
+            let mut id = self.0[i];
+            if id.lsb() < level_lsb {
+                id = id.parent(expand_level);
+                while i > 0 && id.contains(&self.0[i - 1]) {
+                    i -= 1;
+                }
+            }
+            output.push(id);
+            output.extend(id.all_neighbors(expand_level));
+        }
+        self.0 = output;
+        self.normalize();
+    }
+
+    /// Expands the union so it contains all points within `min_radius` of the region,
+    /// using cells at most `max_level_diff` levels above the smallest input cell.
+    pub fn expand_by_radius(&mut self, min_radius: Angle, max_level_diff: u64) {
+        let mut min_level = MAX_LEVEL;
+        for cid in &self.0 {
+            min_level = min(min_level, cid.level());
+        }
+        let radius_level = MIN_WIDTHMETRIC.max_level(min_radius.rad());
+        if radius_level == 0 && min_radius.rad() > MIN_WIDTHMETRIC.value(0) {
+            self.expand_at_level(0);
+        }
+        self.expand_at_level(min(min_level + max_level_diff, radius_level));
+    }
+
+    /// Average area (accurate within about a factor of 1.7).
+    pub fn average_area(&self) -> f64 {
+        AVG_AREAMETRIC.value(MAX_LEVEL as u8) * self.leaf_cell_covered() as f64
+    }
+
+    /// Approximate area (sum of per-cell approximations).
+    pub fn approx_area(&self) -> f64 {
+        self.0.iter().map(|id| Cell::from(id).approx_area()).sum()
+    }
+
+    /// Exact area (sum of per-cell exact areas).
+    pub fn exact_area(&self) -> f64 {
+        self.0.iter().map(|id| Cell::from(id).exact_area()).sum()
+    }
 }
 
 impl Region for CellUnion {
@@ -242,11 +441,50 @@ impl Region for CellUnion {
     fn intersects_cell(&self, c: &Cell) -> bool {
         self.intersects_cellid(&c.id)
     }
+
+    fn cell_union_bound(&self) -> Vec<CellID> {
+        self.cap_bound().cell_union_bound()
+    }
+}
+
+fn lower_bound_cellids(cells: &[CellID], begin: usize, end: usize, id: CellID) -> usize {
+    for i in begin..end {
+        if cells[i] >= id {
+            return i;
+        }
+    }
+    end
+}
+
+fn are_siblings(a: CellID, b: CellID, c: CellID, d: CellID) -> bool {
+    if a.0 ^ b.0 ^ c.0 != d.0 {
+        return false;
+    }
+    let mut mask = d.lsb() << 1;
+    mask = !(mask + (mask << 1));
+    let id_masked = d.0 & mask;
+    (a.0 & mask) == id_masked
+        && (b.0 & mask) == id_masked
+        && (c.0 & mask) == id_masked
+        && !d.is_face()
+}
+
+fn cell_union_difference_internal(out: &mut Vec<CellID>, id: CellID, other: &CellUnion) {
+    if !other.intersects_cellid(&id) {
+        out.push(id);
+        return;
+    }
+    if !other.contains_cellid(&id) {
+        for child in &id.children() {
+            cell_union_difference_internal(out, *child, other);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::consts::EPSILON;
 
     #[test]
     fn test_cellunion_normalization() {
@@ -270,13 +508,9 @@ mod tests {
 
         assert_eq!(cu, exp);
 
-        // add a redundant cell
-        /* TODO(dsymonds)
-        cu.Add(0x808562c000000000)
-        if !reflect.DeepEqual(cu, exp) {
-            t.Errorf("after redundant add, got %v, want %v", cu, exp)
-        }
-        */
+        cu.0.push(CellID(0x808562c000000000));
+        cu.normalize();
+        assert_eq!(cu, exp);
     }
 
     #[test]
@@ -455,196 +689,347 @@ mod tests {
         );
     }
 
-    /*
-    func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *testing.T) {
-        // Decides whether to add "id" and/or some of its descendants to the test case.  If "selected"
-        // is true, then the region covered by "id" *must* be added to the test case (either by adding
-        // "id" itself, or some combination of its descendants, or both).  If cell ids are to the test
-        // case "input", then the corresponding expected result after simplification is added to
-        // "expected".
+    #[test]
+    fn test_cellunion_merge_intersection_difference() {
+        let a = CellUnion(vec![CellID::from_face(0).child_begin_at_level(2)]);
+        let b = CellUnion(vec![CellID::from_face(1).child_begin_at_level(2)]);
+        let m = CellUnion::merge(&[a.clone(), b.clone()]);
+        assert_eq!(m.0.len(), 2);
+        assert!(m.is_normalized());
 
-        if id == 0 {
-            // Initial call: decide whether to add cell(s) from each face.
-            for face := 0; face < 6; face++ {
-                addCells(CellIDFromFace(face), false, input, expected, t)
-            }
-            return
+        let ab = CellUnion::intersection(&a, &b);
+        assert!(ab.0.is_empty());
+
+        let p = CellID::from_face(0).child_begin_at_level(2);
+        let ch = p.children();
+        let x = CellUnion(vec![p]);
+        let y = CellUnion(vec![ch[0]]);
+        let d = CellUnion::difference(&x, &y);
+        assert_eq!(d.0.len(), 3);
+        let merged_back = CellUnion::merge(&[d, y]);
+        assert_eq!(merged_back.0, vec![p]);
+    }
+
+    #[test]
+    fn test_cellunion_contains_intersects_union() {
+        let p = CellID::from_face(0).child_begin_at_level(1);
+        let ch = p.children();
+        let children_u = CellUnion(vec![ch[0], ch[1], ch[2], ch[3]]);
+        let parent_u = CellUnion(vec![p]);
+        assert!(parent_u.contains_cell_union(&children_u));
+        assert!(children_u.intersects_cell_union(&parent_u));
+        assert!(!children_u.contains_cell_union(&parent_u));
+    }
+
+    #[test]
+    fn test_cellunion_intersection_with_cell_id() {
+        let p = CellID::from_face(3).child_begin_at_level(4);
+        let inside = p.child_begin_at_level(8);
+        let mut u = CellUnion(vec![p]);
+        u.normalize();
+        let cap = CellUnion::intersection_with_cell_id(&u, inside);
+        assert_eq!(cap.0, vec![inside]);
+    }
+
+    #[test]
+    fn test_cellunion_from_range_empties_and_full_sphere() {
+        let id_begin = CellID::from_face(0).child_begin_at_level(MAX_LEVEL);
+        assert!(CellUnion::from_range(id_begin, id_begin).0.is_empty());
+
+        let id_end = CellID::from_face(5).child_end_at_level(MAX_LEVEL);
+        assert!(CellUnion::from_range(id_end, id_end).0.is_empty());
+
+        let cu = CellUnion::from_range(id_begin, id_end);
+        assert_eq!(cu.0.len(), 6);
+        assert!(cu.0.iter().all(|c| c.is_face()));
+    }
+
+    #[test]
+    fn test_cellunion_leaf_cells_covered_disjoint_mix() {
+        let have = vec![
+            CellID::from_face(0).child_begin_at_level(MAX_LEVEL),
+            CellID::from_face(0),
+            CellID::from_face(1).child_begin_at_level(1),
+            CellID::from_face(2).child_begin_at_level(2),
+            CellID::from_face(2).child_end_at_level(2).prev(),
+            CellID::from_face(3).child_begin_at_level(14),
+            CellID::from_face(4).child_begin_at_level(27),
+            CellID::from_face(4).child_end_at_level(15).prev(),
+            CellID::from_face(5).child_begin_at_level(30),
+        ];
+        let mut cu = CellUnion(have);
+        cu.normalize();
+        let want = 1u64 + (1 << 6) + (1 << 30) + (1 << 32) + (2 << 56) + (1 << 58) + (1 << 60);
+        assert_eq!(cu.leaf_cell_covered(), want);
+    }
+
+    #[test]
+    fn test_cellunion_contains_point_and_areas() {
+        use crate::s1::{Angle, Rad};
+        use crate::s2::metric::AVG_AREAMETRIC;
+
+        let id = CellID::from_face(2).child_begin_at_level(10);
+        let p = Cell::from(&id).center();
+        let cu = CellUnion(vec![id]);
+        assert!(cu.contains_point(&p));
+
+        let cell = Cell::from(&id);
+        assert_f64_eq!(cu.approx_area(), cell.approx_area());
+        assert_f64_eq!(cu.exact_area(), cell.exact_area());
+        assert_f64_eq!(
+            cu.average_area(),
+            AVG_AREAMETRIC.value(MAX_LEVEL as u8) * cu.leaf_cell_covered() as f64
+        );
+
+        let mut expanded = cu.clone();
+        expanded.expand_by_radius(Angle::from(Rad(1e-6)), 2);
+        assert!(expanded.contains_point(&p));
+    }
+
+    #[test]
+    fn test_cellunion_is_valid_and_is_normalized() {
+        // A properly normalized union is both valid and normalized.
+        let mut cu = CellUnion(vec![
+            CellID::from_face(0).child_begin_at_level(2),
+            CellID::from_face(1).child_begin_at_level(3),
+        ]);
+        cu.normalize();
+        assert!(cu.is_valid());
+        assert!(cu.is_normalized());
+
+        // Unsorted cells: not valid.
+        let unsorted = CellUnion(vec![
+            CellID::from_face(2).child_begin_at_level(2),
+            CellID::from_face(0).child_begin_at_level(2),
+        ]);
+        assert!(!unsorted.is_valid());
+
+        // Overlapping cells (parent + child): not valid.
+        let parent = CellID::from_face(0).child_begin_at_level(2);
+        let child = parent.child_begin_at_level(4);
+        let overlapping = CellUnion(vec![parent, child]);
+        assert!(!overlapping.is_valid());
+
+        // Four siblings without collapsing: valid but not normalized.
+        let p = CellID::from_face(3).child_begin_at_level(5);
+        let ch = p.children();
+        let siblings = CellUnion(vec![ch[0], ch[1], ch[2], ch[3]]);
+        assert!(siblings.is_valid());
+        assert!(!siblings.is_normalized());
+
+        // Empty union is both valid and normalized.
+        let empty = CellUnion(vec![]);
+        assert!(empty.is_valid());
+        assert!(empty.is_normalized());
+    }
+
+    #[test]
+    fn test_cellunion_intersection_overlapping() {
+        // Parent in one union, children in the other — real overlap.
+        let parent = CellID::from_face(0).child_begin_at_level(3);
+        let ch = parent.children();
+
+        let u_parent = CellUnion(vec![parent]);
+        let u_children = CellUnion(vec![ch[0], ch[1], ch[2], ch[3]]);
+
+        // Intersection of parent with its own children yields the four children,
+        // which normalize back to the parent.
+        let inter = CellUnion::intersection(&u_parent, &u_children);
+        assert_eq!(inter.0.len(), 1);
+        assert_eq!(inter.0[0], parent);
+        for c in &ch {
+            assert!(inter.contains_cellid(c));
         }
 
-        if id.IsLeaf() {
-            // The oneIn() call below ensures that the parent of a leaf cell will always be selected (if
-            // we make it that far down the hierarchy).
-            if selected != true {
-                t.Errorf("id IsLeaf() and not selected")
-            }
-            *input = append(*input, id)
-            return
+        // Intersect with just two children.
+        let u_two = CellUnion(vec![ch[0], ch[2]]);
+        let inter2 = CellUnion::intersection(&u_parent, &u_two);
+        assert_eq!(inter2.0.len(), 2);
+        assert!(inter2.contains_cellid(&ch[0]));
+        assert!(inter2.contains_cellid(&ch[2]));
+        assert!(!inter2.contains_cellid(&ch[1]));
+
+        // Intersection is commutative.
+        let inter3 = CellUnion::intersection(&u_two, &u_parent);
+        assert_eq!(inter2, inter3);
+    }
+
+    #[test]
+    fn test_cellunion_expand_at_level() {
+        // A single cell expanded at its own level should include itself + its neighbors.
+        let id = CellID::from_face(1).child_begin_at_level(5);
+        let mut cu = CellUnion(vec![id]);
+        cu.normalize();
+        cu.expand_at_level(5);
+
+        // Must still contain the original cell.
+        assert!(cu.contains_cellid(&id));
+
+        // Must contain all edge neighbors at the same level.
+        for nbr in &id.edge_neighbors() {
+            assert!(
+                cu.contains_cellid(nbr),
+                "expanded union should contain edge neighbor {}",
+                nbr
+            );
         }
 
-        // The following code ensures that the probability of selecting a cell at each level is
-        // approximately the same, i.e. we test normalization of cells at all levels.
-        if !selected && oneIn(maxLevel-id.Level()) {
-            //  Once a cell has been selected, the expected output is predetermined.  We then make sure
-            //  that cells are selected that will normalize to the desired output.
-            *expected = append(*expected, id)
-            selected = true
-
-        }
-
-        // With the rnd.OneIn() constants below, this function adds an average
-        // of 5/6 * (kMaxLevel - level) cells to "input" where "level" is the
-        // level at which the cell was first selected (level 15 on average).
-        // Therefore the average number of input cells in a test case is about
-        // (5/6 * 15 * 6) = 75.  The average number of output cells is about 6.
-
-        // If a cell is selected, we add it to "input" with probability 5/6.
-        added := false
-        if selected && !oneIn(6) {
-            *input = append(*input, id)
-            added = true
-        }
-        numChildren := 0
-        for child := id.ChildBegin(); child != id.ChildEnd(); child = child.Next() {
-            // If the cell is selected, on average we recurse on 4/12 = 1/3 child.
-            // This intentionally may result in a cell and some of its children
-            // being included in the test case.
-            //
-            // If the cell is not selected, on average we recurse on one child.
-            // We also make sure that we do not recurse on all 4 children, since
-            // then we might include all 4 children in the input case by accident
-            // (in which case the expected output would not be correct).
-            recurse := false
-            if selected {
-                recurse = oneIn(12)
-            } else {
-                recurse = oneIn(4)
-            }
-            if recurse && numChildren < 3 {
-                addCells(child, selected, input, expected, t)
-                numChildren++
-            }
-            // If this cell was selected but the cell itself was not added, we
-            // must ensure that all 4 children (or some combination of their
-            // descendants) are added.
-
-            if selected && !added {
-                addCells(child, selected, input, expected, t)
-            }
+        // Expanding a deeper cell at a coarser level: cell gets promoted to its parent
+        // at that level, so we also get the parent's neighbors.
+        let deep = CellID::from_face(2).child_begin_at_level(10);
+        let mut cu2 = CellUnion(vec![deep]);
+        cu2.normalize();
+        cu2.expand_at_level(8);
+        let promoted = deep.parent(8);
+        assert!(cu2.contains_cellid(&promoted));
+        for nbr in &promoted.edge_neighbors() {
+            assert!(cu2.contains_cellid(nbr));
         }
     }
 
-    func TestCellUnionNormalizePseudoRandom(t *testing.T) {
-        // Try a bunch of random test cases, and keep track of average statistics
-        // for normalization (to see if they agree with the analysis above).
+    #[test]
+    fn test_cellunion_difference_partial_overlap() {
+        let parent = CellID::from_face(0).child_begin_at_level(4);
+        let ch = parent.children();
+        // x has child 0 and child 1
+        let x = CellUnion(vec![ch[0], ch[1]]);
+        // y has child 1 and child 2
+        let y = CellUnion(vec![ch[1], ch[2]]);
 
-        inSum := 0
-        outSum := 0
-        iters := 2000
+        // x - y should be just child 0
+        let diff = CellUnion::difference(&x, &y);
+        assert_eq!(diff.0, vec![ch[0]]);
 
-        for i := 0; i < iters; i++ {
-            input := []CellID{}
-            expected := []CellID{}
-            addCells(CellID(0), false, &input, &expected, t)
-            inSum += len(input)
-            outSum += len(expected)
-            cellunion := CellUnion(input)
-            cellunion.Normalize()
+        // y - x should be just child 2
+        let diff2 = CellUnion::difference(&y, &x);
+        assert_eq!(diff2.0, vec![ch[2]]);
 
-            if len(expected) != len(cellunion) {
-                t.Errorf("Expected size of union to be %d, but got %d.",
-                    len(expected), len(cellunion))
-            }
-
-            // Test GetCapBound().
-            cb := cellunion.CapBound()
-            for _, ci := range cellunion {
-                if !cb.ContainsCell(CellFromCellID(ci)) {
-                    t.Errorf("CapBound %v of union %v should contain cellID %v", cb, cellunion, ci)
-                }
-            }
-
-            for _, j := range input {
-                if !cellunion.ContainsCellID(j) {
-                    t.Errorf("Expected containment of CellID %v", j)
-                }
-
-                if cellunion.IntersectsCellID(j) == false {
-                    t.Errorf("Expected intersection with %v.", j)
-                }
-
-                if !j.isFace() {
-                    if cellunion.IntersectsCellID(j.immediateParent()) == false {
-                        t.Errorf("Expected intersection with parent cell %v.", j.immediateParent())
-                        if j.Level() > 1 {
-                            if cellunion.IntersectsCellID(j.immediateParent().immediateParent()) == false {
-                                t.Errorf("Expected intersection with parent's parent %v.",
-                                    j.immediateParent().immediateParent())
-                            }
-                            if cellunion.IntersectsCellID(j.Parent(0)) == false {
-                                t.Errorf("Expected intersection with parent %v at level 0.", j.Parent(0))
-                            }
-                        }
-                    }
-                }
-
-                if !j.IsLeaf() {
-                    if cellunion.ContainsCellID(j.ChildBegin()) == false {
-                        t.Errorf("Expected containment of %v.", j.ChildBegin())
-                    }
-                    if cellunion.IntersectsCellID(j.ChildBegin()) == false {
-                        t.Errorf("Expected intersection with %v.", j.ChildBegin())
-                    }
-                    if cellunion.ContainsCellID(j.ChildEnd().Prev()) == false {
-                        t.Errorf("Expected containment of %v.", j.ChildEnd().Prev())
-                    }
-                    if cellunion.IntersectsCellID(j.ChildEnd().Prev()) == false {
-                        t.Errorf("Expected intersection with %v.", j.ChildEnd().Prev())
-                    }
-                    if cellunion.ContainsCellID(j.ChildBeginAtLevel(maxLevel)) == false {
-                        t.Errorf("Expected containment of %v.", j.ChildBeginAtLevel(maxLevel))
-                    }
-                    if cellunion.IntersectsCellID(j.ChildBeginAtLevel(maxLevel)) == false {
-                        t.Errorf("Expected intersection with %v.", j.ChildBeginAtLevel(maxLevel))
-                    }
-                }
-            }
-
-            for _, exp := range expected {
-                if !exp.isFace() {
-                    if cellunion.ContainsCellID(exp.Parent(exp.Level() - 1)) {
-                        t.Errorf("cellunion should not contain its parent %v", exp.Parent(exp.Level()-1))
-                    }
-                    if cellunion.ContainsCellID(exp.Parent(0)) {
-                        t.Errorf("cellunion should not contain the top level parent %v", exp.Parent(0))
-                    }
-                }
-            }
-
-            var test []CellID
-            var dummy []CellID
-            addCells(CellID(0), false, &test, &dummy, t)
-            for _, j := range test {
-                intersects := false
-                contains := false
-                for _, k := range expected {
-                    if k.Contains(j) {
-                        contains = true
-                    }
-                    if k.Intersects(j) {
-                        intersects = true
-                    }
-                }
-                if cellunion.ContainsCellID(j) != contains {
-                    t.Errorf("Expected contains with %v.", (uint64)(j))
-                }
-                if cellunion.IntersectsCellID(j) != intersects {
-                    t.Errorf("Expected intersection with %v.", (uint64)(j))
-                }
-            }
-        }
-        t.Logf("avg in %.2f, avg out %.2f\n", (float64)(inSum)/(float64)(iters), (float64)(outSum)/(float64)(iters))
+        // (x - y) ∪ (x ∩ y) should reconstruct x
+        let inter = CellUnion::intersection(&x, &y);
+        assert_eq!(inter.0, vec![ch[1]]);
+        let reconstructed = CellUnion::merge(&[diff, inter]);
+        assert_eq!(reconstructed.0, vec![ch[0], ch[1]]);
     }
-    */
+
+    #[test]
+    fn test_cellunion_whole_sphere() {
+        let cu = CellUnion::whole_sphere();
+        assert_eq!(cu.0.len(), 6);
+        assert!(cu.is_valid());
+        assert!(cu.is_normalized());
+        for face in 0..6 {
+            let id = CellID::from_face(face);
+            assert!(cu.contains_cellid(&id));
+        }
+        // Must contain an arbitrary deeply nested cell.
+        let deep = CellID::from_face(3).child_begin_at_level(MAX_LEVEL);
+        assert!(cu.contains_cellid(&deep));
+    }
+
+    #[test]
+    fn test_cellunion_empty() {
+        let empty = CellUnion(vec![]);
+
+        // Valid and normalized.
+        assert!(empty.is_valid());
+        assert!(empty.is_normalized());
+
+        // Contains / intersects nothing.
+        let face0 = CellID::from_face(0);
+        assert!(!empty.contains_cellid(&face0));
+        assert!(!empty.intersects_cellid(&face0));
+
+        let p = Point::from(&face0);
+        assert!(!empty.contains_point(&p));
+
+        // Operations with empty unions.
+        let other = CellUnion(vec![face0]);
+        assert!(!empty.contains_cell_union(&other));
+        assert!(!empty.intersects_cell_union(&other));
+        assert!(empty.contains_cell_union(&CellUnion(vec![])));
+
+        // Union / intersection / difference with empty.
+        let u = CellUnion::union(&empty, &other);
+        assert_eq!(u.0, vec![face0]);
+        let u2 = CellUnion::union(&other, &empty);
+        assert_eq!(u2.0, vec![face0]);
+
+        let inter = CellUnion::intersection(&empty, &other);
+        assert!(inter.0.is_empty());
+
+        let diff = CellUnion::difference(&other, &empty);
+        assert_eq!(diff.0, vec![face0]);
+        let diff2 = CellUnion::difference(&empty, &other);
+        assert!(diff2.0.is_empty());
+
+        // Areas.
+        assert_eq!(empty.average_area(), 0.0);
+        assert_eq!(empty.approx_area(), 0.0);
+        assert_eq!(empty.exact_area(), 0.0);
+
+        // Leaf cells covered.
+        assert_eq!(empty.leaf_cell_covered(), 0);
+
+        // Region bounds.
+        let cap = empty.cap_bound();
+        assert!(cap.is_empty());
+    }
+
+    #[test]
+    fn test_cellunion_invalid_cellid_not_valid() {
+        // A CellUnion containing an invalid CellID(0) should not be valid.
+        let cu = CellUnion(vec![CellID(0)]);
+        assert!(!cu.is_valid());
+        assert!(!cu.is_normalized());
+    }
+
+    #[test]
+    fn test_cellunion_duplicate_cells_not_valid() {
+        let id = CellID::from_face(1).child_begin_at_level(5);
+        let cu = CellUnion(vec![id, id]);
+        assert!(!cu.is_valid());
+    }
+
+    #[test]
+    fn test_are_siblings() {
+        // The four children of a cell are siblings.
+        let parent = CellID::from_face(2).child_begin_at_level(4);
+        let ch = parent.children();
+        assert!(are_siblings(ch[0], ch[1], ch[2], ch[3]));
+
+        // Permutation should still work since the XOR test is order-sensitive
+        // but the mask test checks identity regardless of order.
+        assert!(are_siblings(ch[3], ch[2], ch[1], ch[0]));
+
+        // Replacing one child with an unrelated cell makes them non-siblings.
+        let other = CellID::from_face(3).child_begin_at_level(5);
+        assert!(!are_siblings(ch[0], ch[1], ch[2], other));
+
+        // Face cells are never siblings (guard in are_siblings).
+        let faces: Vec<CellID> = (0..4).map(CellID::from_face).collect();
+        assert!(!are_siblings(faces[0], faces[1], faces[2], faces[3]));
+    }
+
+    #[test]
+    fn test_cellunion_leaf_cells_covered_full_sphere() {
+        // 5-face union: all faces except one.
+        let five_faces = CellUnion(
+            (0..5).map(CellID::from_face).collect(),
+        );
+        let one_face_leaves = 1u64 << (MAX_LEVEL * 2);
+        assert_eq!(five_faces.leaf_cell_covered(), 5 * one_face_leaves);
+
+        // Full sphere (6 faces).
+        let full = CellUnion::whole_sphere();
+        assert_eq!(full.leaf_cell_covered(), 6 * one_face_leaves);
+
+        // Expanding a single face at level 0 adds its 4 edge-neighbor faces.
+        // Face 0's opposite face (face 5) shares no edges, so we get 5 faces.
+        let id = CellID::from_face(0);
+        let mut expanded = CellUnion(vec![id]);
+        expanded.expand_at_level(0);
+        assert_eq!(expanded.leaf_cell_covered(), 5 * one_face_leaves);
+    }
 
     fn test_denorm_case(
         name: &str,
@@ -723,203 +1108,4 @@ mod tests {
     }
 }
 
-/*
-func TestCellUnionRectBound(t *testing.T) {
-    tests := []struct {
-        cu   *CellUnion
-        want Rect
-    }{
-        {&CellUnion{}, EmptyRect()},
-        {
-            &CellUnion{CellIDFromFace(1)},
-            Rect{
-                r1.Interval{-math.Pi / 4, math.Pi / 4},
-                s1.Interval{math.Pi / 4, 3 * math.Pi / 4},
-            },
-        },
-        {
-            &CellUnion{
-                0x808c000000000000, // Big SFO
-            },
-            Rect{
-                r1.Interval{
-                    float64(s1.Degree * 34.644220547108482),
-                    float64(s1.Degree * 38.011928357226651),
-                },
-                s1.Interval{
-                    float64(s1.Degree * -124.508522987668428),
-                    float64(s1.Degree * -121.628309835221216),
-                },
-            },
-        },
-        {
-            &CellUnion{
-                0x89c4000000000000, // Big NYC
-            },
-            Rect{
-                r1.Interval{
-                    float64(s1.Degree * 38.794595155857657),
-                    float64(s1.Degree * 41.747046884651063),
-                },
-                s1.Interval{
-                    float64(s1.Degree * -76.456308667788633),
-                    float64(s1.Degree * -73.465162142654819),
-                },
-            },
-        },
-        {
-            &CellUnion{
-                0x89c4000000000000, // Big NYC
-                0x808c000000000000, // Big SFO
-            },
-            Rect{
-                r1.Interval{
-                    float64(s1.Degree * 34.644220547108482),
-                    float64(s1.Degree * 41.747046884651063),
-                },
-                s1.Interval{
-                    float64(s1.Degree * -124.508522987668428),
-                    float64(s1.Degree * -73.465162142654819),
-                },
-            },
-        },
-    }
-
-    for _, test := range tests {
-        if got := test.cu.RectBound(); !rectsApproxEqual(got, test.want, epsilon, epsilon) {
-            t.Errorf("%v.RectBound() = %v, want %v", test.cu, got, test.want)
-        }
-    }
-}
-
-func TestCellUnionLeafCellsCovered(t *testing.T) {
-    tests := []struct {
-        have []CellID
-        want int64
-    }{
-        {},
-        {
-            have: []CellID{},
-            want: 0,
-        },
-        {
-            // One leaf cell on face 0.
-            have: []CellID{
-                CellIDFromFace(0).ChildBeginAtLevel(maxLevel),
-            },
-            want: 1,
-        },
-        {
-            // Face 0 itself (which includes the previous leaf cell).
-            have: []CellID{
-                CellIDFromFace(0).ChildBeginAtLevel(maxLevel),
-                CellIDFromFace(0),
-            },
-            want: 1 << 60,
-        },
-        /*
-            TODO(roberts): Once Expand is implemented, add the two tests for these
-            // Five faces.
-            cell_union.Expand(0),
-            want: 5 << 60,
-            // Whole world.
-            cell_union.Expand(0),
-            want: 6 << 60,
-        */
-        {
-            // Add some disjoint cells.
-            have: []CellID{
-                CellIDFromFace(0).ChildBeginAtLevel(maxLevel),
-                CellIDFromFace(0),
-                CellIDFromFace(1).ChildBeginAtLevel(1),
-                CellIDFromFace(2).ChildBeginAtLevel(2),
-                CellIDFromFace(2).ChildEndAtLevel(2).Prev(),
-                CellIDFromFace(3).ChildBeginAtLevel(14),
-                CellIDFromFace(4).ChildBeginAtLevel(27),
-                CellIDFromFace(4).ChildEndAtLevel(15).Prev(),
-                CellIDFromFace(5).ChildBeginAtLevel(30),
-            },
-            want: 1 + (1 << 6) + (1 << 30) + (1 << 32) +
-                (2 << 56) + (1 << 58) + (1 << 60),
-        },
-    }
-
-    for _, test := range tests {
-        cu := CellUnion(test.have)
-        cu.Normalize()
-        if got := cu.LeafCellsCovered(); got != test.want {
-            t.Errorf("CellUnion(%v).LeafCellsCovered() = %v, want %v", cu, got, test.want)
-        }
-    }
-}
-
-func TestCellUnionFromRange(t *testing.T) {
-    for iter := 0; iter < 100; iter++ {
-        min := randomCellIDForLevel(maxLevel)
-        max := randomCellIDForLevel(maxLevel)
-        if min > max {
-            min, max = max, min
-        }
-
-        cu := CellUnionFromRange(min, max.Next())
-        if len(cu) <= 0 {
-            t.Errorf("len(CellUnionFromRange(%v, %v)) = %d, want > 0", min, max.Next(), len(cu))
-        }
-        if min != cu[0].RangeMin() {
-            t.Errorf("%v.RangeMin of CellUnion should not be below the minimum value it was created from %v", cu[0], min)
-        }
-        if max != cu[len(cu)-1].RangeMax() {
-            t.Errorf("%v.RangeMax of CellUnion should not be above the maximum value it was created from %v", cu[len(cu)-1], max)
-        }
-        for i := 1; i < len(cu); i++ {
-            if got, want := cu[i].RangeMin(), cu[i-1].RangeMax().Next(); got != want {
-                t.Errorf("%v.RangeMin() = %v, want %v", cu[i], got, want)
-            }
-        }
-    }
-
-    // Focus on test cases that generate an empty or full range.
-
-    // Test an empty range before the minimum CellID.
-    idBegin := CellIDFromFace(0).ChildBeginAtLevel(maxLevel)
-    cu := CellUnionFromRange(idBegin, idBegin)
-    if len(cu) != 0 {
-        t.Errorf("CellUnionFromRange with begin and end as the first CellID should be empty, got %d", len(cu))
-    }
-
-    // Test an empty range after the maximum CellID.
-    idEnd := CellIDFromFace(5).ChildEndAtLevel(maxLevel)
-    cu = CellUnionFromRange(idEnd, idEnd)
-    if len(cu) != 0 {
-        t.Errorf("CellUnionFromRange with begin and end as the last CellID should be empty, got %d", len(cu))
-    }
-
-    // Test the full sphere.
-    cu = CellUnionFromRange(idBegin, idEnd)
-    if len(cu) != 6 {
-        t.Errorf("CellUnionFromRange from first CellID to last CellID should have 6 cells, got %d", len(cu))
-    }
-
-    for i := 0; i < len(cu); i++ {
-        if !cu[i].isFace() {
-            t.Errorf("CellUnionFromRange for full sphere cu[%d].isFace() = %t, want %t", i, cu[i].isFace(), true)
-        }
-    }
-}
-
-func BenchmarkCellUnionFromRange(b *testing.B) {
-    x := CellIDFromFace(0).ChildBeginAtLevel(maxLevel)
-    y := CellIDFromFace(5).ChildEndAtLevel(maxLevel)
-    for i := 0; i < b.N; i++ {
-        CellUnionFromRange(x, y)
-    }
-}
-*/
-
-// BUG: Differences from C++:
-//  Contains(CellUnion)/Intersects(CellUnion)
-//  Union(CellUnion)/Intersection(CellUnion)/Difference(CellUnion)
-//  Expand
-//  ContainsPoint
-//  AverageArea/ApproxArea/ExactArea
-//
+// Binary Encode/Decode for CellUnion (as in golang/geo) is not implemented.

--- a/src/s2/cellunion.rs
+++ b/src/s2/cellunion.rs
@@ -1013,9 +1013,7 @@ mod tests {
     #[test]
     fn test_cellunion_leaf_cells_covered_full_sphere() {
         // 5-face union: all faces except one.
-        let five_faces = CellUnion(
-            (0..5).map(CellID::from_face).collect(),
-        );
+        let five_faces = CellUnion((0..5).map(CellID::from_face).collect());
         let one_face_leaves = 1u64 << (MAX_LEVEL * 2);
         assert_eq!(five_faces.leaf_cell_covered(), 5 * one_face_leaves);
 


### PR DESCRIPTION
## Summary

Brings `CellUnion` in line with the geometric API and behavior of [google/s2geometry](https://github.com/google/s2geometry) (`s2cell_union`) and [golang/geo](https://github.com/golang/geo) (`cellunion`), as requested in #76.

## Implemented

- **Validity / shape**: `is_valid`, `is_normalized`
- **Set-style ops on normalized unions**: `merge`, `union`, `intersection`, `difference`, `intersection_with_cell_id`
- **Relations**: `contains_cell_union`, `intersects_cell_union`, `contains_point`
- **Expansion**: `expand_at_level`, `expand_by_radius` (using `MIN_WIDTHMETRIC`)
- **Areas**: `average_area`, `approx_area`, `exact_area` (via `Cell`)
- **Whole sphere**: `whole_sphere()` (six face cells)
- **`Region`**: `cell_union_bound` delegates to the bounding cap’s `cell_union_bound`, matching Go’s behavior
- **`CellID`**: `lsb_for_level` is `pub(crate)` so `expand_at_level` can use the same LSB logic as the rest of the crate

Internal helpers: `lower_bound_cellids`, `are_siblings`, recursive `difference` core.

## Tests

Expanded unit tests cover normalization, containment/intersection probes, merge/intersection/difference, `from_range` edge cases, denormalize, empty union behavior, invalid/duplicate IDs, sibling detection, `whole_sphere`, leaf-cell counts (including five vs six faces and `expand_at_level(0)`), overlapping intersection, and area helpers.

## Out of scope (documented)

- Binary **encode/decode** for `CellUnion` (present in Go; not ported here; see module comment)
- C++-specific surface (protobuf packing, `Iterator`, `Clear`/`Release`, etc.) — Rust uses `Vec<CellID>` idioms instead
- Full **randomized / stress** suites from upstream test files (replaced with targeted tests)

Closes #76
