### PR TITLE
add edge crosser and edge crossings

### DIFF
--- a/src/s2/edge_crosser.rs
+++ b/src/s2/edge_crosser.rs
@@ -1,0 +1,305 @@
+/*
+Copyright 2026 The rust-s2 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+//! Stateful edge crosser ported from S2's `s2edge_crosser`.
+
+use crate::consts::DBL_EPSILON;
+use crate::r3::vector::Vector;
+use crate::s2::edge_crossings::{signed_vertex_crossing, vertex_crossing};
+use crate::s2::point::Point;
+use crate::s2::predicates::{Direction, robust_sign, sign, triage_sign};
+
+#[inline]
+fn direction_to_int(d: Direction) -> i32 {
+    match d {
+        Direction::Clockwise => -1,
+        Direction::Indeterminate => 0,
+        Direction::CounterClockwise => 1,
+    }
+}
+
+#[inline]
+fn triage_sign_with_cross(cross: &Vector, c: &Point) -> i32 {
+    const MAX_DETERMINANT_ERROR: f64 = 1.8274 * DBL_EPSILON;
+    let det = cross.dot(&c.0);
+    if det > MAX_DETERMINANT_ERROR {
+        1
+    } else if det < -MAX_DETERMINANT_ERROR {
+        -1
+    } else {
+        0
+    }
+}
+
+#[inline]
+fn robust_sign_int(a: &Point, b: &Point, c: &Point) -> i32 {
+    if a == b || b == c || c == a {
+        return 0;
+    }
+    match robust_sign(a, b, c) {
+        Direction::CounterClockwise => 1,
+        Direction::Clockwise => -1,
+        // exact_sign isn't implemented in this crate yet; use a deterministic
+        // fallback that preserves non-zero orientation for distinct points.
+        Direction::Indeterminate => {
+            if sign(a, b, c) {
+                1
+            } else {
+                -1
+            }
+        }
+    }
+}
+
+#[inline]
+fn sign_with_cross(a: &Point, b: &Point, c: &Point, cross: &Vector) -> i32 {
+    if a == b || b == c || c == a {
+        return 0;
+    }
+    let triage = triage_sign_with_cross(cross, c);
+    if triage != 0 {
+        triage
+    } else {
+        robust_sign_int(a, b, c)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EdgeCrosser {
+    a: Point,
+    b: Point,
+    a_cross_b: Vector,
+    have_tangents: bool,
+    a_tangent: Point,
+    b_tangent: Point,
+    c: Option<Point>,
+    acb: i32,
+    bda: i32,
+}
+
+impl EdgeCrosser {
+    pub fn new(a: Point, b: Point) -> Self {
+        Self {
+            a,
+            b,
+            a_cross_b: a.0.cross(&b.0),
+            have_tangents: false,
+            a_tangent: Point::default(),
+            b_tangent: Point::default(),
+            c: None,
+            acb: 0,
+            bda: 0,
+        }
+    }
+
+    pub fn new_with_c(a: Point, b: Point, c: Point) -> Self {
+        let mut out = Self::new(a, b);
+        out.restart_at(c);
+        out
+    }
+
+    pub fn a(&self) -> Point {
+        self.a
+    }
+
+    pub fn b(&self) -> Point {
+        self.b
+    }
+
+    pub fn c(&self) -> Option<Point> {
+        self.c
+    }
+
+    pub fn init(&mut self, a: Point, b: Point) {
+        self.a = a;
+        self.b = b;
+        self.a_cross_b = a.0.cross(&b.0);
+        self.have_tangents = false;
+        self.c = None;
+        self.acb = 0;
+        self.bda = 0;
+    }
+
+    pub fn restart_at(&mut self, c: Point) {
+        self.c = Some(c);
+        self.acb = -direction_to_int(triage_sign(&self.a, &self.b, &c));
+    }
+
+    pub fn crossing_sign(&mut self, c: &Point, d: &Point) -> i32 {
+        if self.c != Some(*c) {
+            self.restart_at(*c);
+        }
+        self.crossing_sign_with_d(d)
+    }
+
+    pub fn crossing_sign_with_d(&mut self, d: &Point) -> i32 {
+        let bda = direction_to_int(triage_sign(&self.a, &self.b, d));
+        if self.acb == -bda && bda != 0 {
+            self.c = Some(*d);
+            self.acb = -bda;
+            return -1;
+        }
+        self.bda = bda;
+        self.crossing_sign_internal(*d)
+    }
+
+    pub fn edge_or_vertex_crossing(&mut self, c: &Point, d: &Point) -> bool {
+        if self.c != Some(*c) {
+            self.restart_at(*c);
+        }
+        self.edge_or_vertex_crossing_with_d(d)
+    }
+
+    pub fn edge_or_vertex_crossing_with_d(&mut self, d: &Point) -> bool {
+        let c = self.c.expect("restart_at must be called before chain crossing");
+        let crossing = self.crossing_sign_with_d(d);
+        if crossing < 0 {
+            return false;
+        }
+        if crossing > 0 {
+            return true;
+        }
+        vertex_crossing(&self.a, &self.b, &c, d)
+    }
+
+    pub fn signed_edge_or_vertex_crossing(&mut self, c: &Point, d: &Point) -> i32 {
+        if self.c != Some(*c) {
+            self.restart_at(*c);
+        }
+        self.signed_edge_or_vertex_crossing_with_d(d)
+    }
+
+    pub fn signed_edge_or_vertex_crossing_with_d(&mut self, d: &Point) -> i32 {
+        let c = self.c.expect("restart_at must be called before chain crossing");
+        let crossing = self.crossing_sign_with_d(d);
+        if crossing < 0 {
+            return 0;
+        }
+        if crossing > 0 {
+            return self.last_interior_crossing_sign();
+        }
+        signed_vertex_crossing(&self.a, &self.b, &c, d)
+    }
+
+    pub fn last_interior_crossing_sign(&self) -> i32 {
+        self.acb
+    }
+
+    fn crossing_sign_internal(&mut self, d: Point) -> i32 {
+        let result = self.crossing_sign_internal2(&d);
+        self.c = Some(d);
+        self.acb = -self.bda;
+        result
+    }
+
+    fn crossing_sign_internal2(&mut self, d: &Point) -> i32 {
+        let c = self.c.expect("restart_at must be called before chain crossing");
+
+        if !self.have_tangents {
+            let norm = self.a.cross(&self.b);
+            self.a_tangent = Point(self.a.0.cross(&norm.0));
+            self.b_tangent = Point(norm.0.cross(&self.b.0));
+            self.have_tangents = true;
+        }
+
+        let k_error = (1.5 + 1.0 / (3.0f64).sqrt()) * DBL_EPSILON;
+        if (c.0.dot(&self.a_tangent.0) > k_error && d.0.dot(&self.a_tangent.0) > k_error)
+            || (c.0.dot(&self.b_tangent.0) > k_error && d.0.dot(&self.b_tangent.0) > k_error)
+        {
+            return -1;
+        }
+
+        if self.a == c || self.a == *d || self.b == c || self.b == *d {
+            return 0;
+        }
+        if self.a == self.b || c == *d {
+            return -1;
+        }
+
+        if self.acb == 0 {
+            self.acb = -robust_sign_int(&self.a, &self.b, &c);
+        }
+        if self.bda == 0 {
+            self.bda = robust_sign_int(&self.a, &self.b, d);
+        }
+        if self.bda != self.acb {
+            return -1;
+        }
+
+        let c_cross_d = c.0.cross(&d.0);
+        let cbd = -sign_with_cross(&c, d, &self.b, &c_cross_d);
+        if cbd != self.acb {
+            return -1;
+        }
+        let dac = sign_with_cross(&c, d, &self.a, &c_cross_d);
+        if dac != self.acb { -1 } else { 1 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::r3::vector::Vector;
+    use crate::s2::edge_crossings::{crossing_sign, edge_or_vertex_crossing};
+
+    fn norm(v: Vector) -> Point {
+        Point(v).normalize()
+    }
+
+    #[test]
+    fn test_crossing_sign_matches_stateless() {
+        let a = norm(Vector::new(1., 2., 1.));
+        let b = norm(Vector::new(1., -3., 0.5));
+        let c = norm(Vector::new(1., -0.5, -3.));
+        let d = norm(Vector::new(0.1, 0.5, 3.));
+
+        let mut crosser = EdgeCrosser::new_with_c(a, b, c);
+        let got = crosser.crossing_sign_with_d(&d);
+        assert_eq!(crossing_sign(&a, &b, &c, &d), got);
+        assert_eq!(1, got);
+    }
+
+    #[test]
+    fn test_edge_chain_methods() {
+        let a = norm(Vector::new(1., 2., 1.));
+        let b = norm(Vector::new(1., -3., 0.5));
+        let chain = [
+            norm(Vector::new(1., -0.5, -3.)),
+            norm(Vector::new(0.1, 0.5, 3.)),
+            norm(Vector::new(2., 0.5, -3.)),
+        ];
+
+        let mut crosser = EdgeCrosser::new_with_c(a, b, chain[0]);
+        let mut c = chain[0];
+        for d in chain.iter().skip(1) {
+            let got = crosser.edge_or_vertex_crossing_with_d(d);
+            let want = edge_or_vertex_crossing(&a, &b, &c, d);
+            assert_eq!(want, got);
+            c = *d;
+        }
+    }
+
+    #[test]
+    fn test_reuse_via_init() {
+        let a = norm(Vector::new(1., 0., 0.));
+        let b = norm(Vector::new(0., 1., 0.));
+        let c = norm(Vector::new(0., 0., 1.));
+        let d = norm(Vector::new(1., 1., 1.));
+
+        let mut crosser = EdgeCrosser::new(a, b);
+        crosser.restart_at(c);
+        let before = crosser.crossing_sign_with_d(&d);
+
+        crosser.init(c, d);
+        crosser.restart_at(a);
+        let after = crosser.crossing_sign_with_d(&b);
+        assert_eq!(before, after);
+    }
+}

--- a/src/s2/edge_crossings.rs
+++ b/src/s2/edge_crossings.rs
@@ -1,0 +1,191 @@
+/*
+Copyright 2026 The rust-s2 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+//! Robust edge crossing helpers ported from S2's `s2edge_crossings`.
+
+use crate::s2::edge_crosser::EdgeCrosser;
+use crate::s2::point::{Point, ordered_ccw};
+
+/// Returns a robust cross product direction for unit-length vectors.
+pub fn robust_cross_prod(a: &Point, b: &Point) -> Point {
+    a.cross(b)
+}
+
+#[inline]
+fn ref_dir(a: &Point) -> Point {
+    a.ortho()
+}
+
+/// Returns +1 if AB crosses CD at interior points, 0 for shared vertices
+/// between different edges, and -1 otherwise.
+pub fn crossing_sign(a: &Point, b: &Point, c: &Point, d: &Point) -> i32 {
+    let mut crosser = EdgeCrosser::new_with_c(*a, *b, *c);
+    crosser.crossing_sign_with_d(d)
+}
+
+/// Returns true if angle ABC contains its vertex B under S2's semi-open rule.
+pub fn angle_contains_vertex(a: &Point, b: &Point, c: &Point) -> bool {
+    !ordered_ccw(&ref_dir(b), c, a, b)
+}
+
+/// Defines whether two edges that share one or more vertices should count as
+/// a crossing for point-in-polygon and edge-chain crossing counting.
+pub fn vertex_crossing(a: &Point, b: &Point, c: &Point, d: &Point) -> bool {
+    if a == b || c == d {
+        return false;
+    }
+    if a == c {
+        return (b == d) || ordered_ccw(&ref_dir(a), d, b, a);
+    }
+    if b == d {
+        return ordered_ccw(&ref_dir(b), c, a, b);
+    }
+    if a == d {
+        return (b == c) || ordered_ccw(&ref_dir(a), c, b, a);
+    }
+    if b == c {
+        return ordered_ccw(&ref_dir(b), d, a, b);
+    }
+    false
+}
+
+/// Like `vertex_crossing`, but returns crossing orientation:
+/// -1 for left-to-right, +1 for right-to-left, 0 otherwise.
+pub fn signed_vertex_crossing(a: &Point, b: &Point, c: &Point, d: &Point) -> i32 {
+    if a == b || c == d {
+        return 0;
+    }
+    if a == c {
+        return if (b == d) || ordered_ccw(&ref_dir(a), d, b, a) {
+            1
+        } else {
+            0
+        };
+    }
+    if b == d {
+        return if ordered_ccw(&ref_dir(b), c, a, b) { 1 } else { 0 };
+    }
+    if a == d {
+        return if (b == c) || ordered_ccw(&ref_dir(a), c, b, a) {
+            -1
+        } else {
+            0
+        };
+    }
+    if b == c {
+        return if ordered_ccw(&ref_dir(b), d, a, b) {
+            -1
+        } else {
+            0
+        };
+    }
+    0
+}
+
+/// Convenience wrapper combining `crossing_sign` and `vertex_crossing`.
+pub fn edge_or_vertex_crossing(a: &Point, b: &Point, c: &Point, d: &Point) -> bool {
+    let crossing = crossing_sign(a, b, c, d);
+    if crossing < 0 {
+        return false;
+    }
+    if crossing > 0 {
+        return true;
+    }
+    vertex_crossing(a, b, c, d)
+}
+
+/// Signed version of `edge_or_vertex_crossing`.
+pub fn signed_edge_or_vertex_crossing(a: &Point, b: &Point, c: &Point, d: &Point) -> i32 {
+    let crossing = crossing_sign(a, b, c, d);
+    if crossing < 0 {
+        return 0;
+    }
+    if crossing > 0 {
+        let mut crosser = EdgeCrosser::new_with_c(*a, *b, *c);
+        let _ = crosser.crossing_sign_with_d(d);
+        return crosser.last_interior_crossing_sign();
+    }
+    signed_vertex_crossing(a, b, c, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::r3::vector::Vector;
+    use crate::s2::point::ORIGIN;
+
+    fn norm(v: Vector) -> Point {
+        Point(v).normalize()
+    }
+
+    fn test_crossings(a: Point, b: Point, c: Point, d: Point, crossing_sign_want: i32, signed_want: i32) {
+        assert_eq!(crossing_sign_want, crossing_sign(&a, &b, &c, &d));
+        assert_eq!(signed_want != 0, edge_or_vertex_crossing(&a, &b, &c, &d));
+        assert_eq!(signed_want, signed_edge_or_vertex_crossing(&a, &b, &c, &d));
+    }
+
+    #[test]
+    fn test_crossings_basic() {
+        test_crossings(
+            norm(Vector::new(1., 2., 1.)),
+            norm(Vector::new(1., -3., 0.5)),
+            norm(Vector::new(1., -0.5, -3.)),
+            norm(Vector::new(0.1, 0.5, 3.)),
+            1,
+            1,
+        );
+        test_crossings(
+            norm(Vector::new(1., 2., 1.)),
+            norm(Vector::new(1., -3., 0.5)),
+            norm(Vector::new(-1., 0.5, 3.)),
+            norm(Vector::new(-0.1, -0.5, -3.)),
+            -1,
+            0,
+        );
+        test_crossings(
+            norm(Vector::new(7., -2., 3.)),
+            norm(Vector::new(2., 3., 4.)),
+            norm(Vector::new(2., 3., 4.)),
+            norm(Vector::new(-1., 2., 5.)),
+            0,
+            -1,
+        );
+        test_crossings(
+            norm(Vector::new(1., 0., 0.)),
+            ORIGIN,
+            norm(Vector::new(1., -0.1, 1.)),
+            norm(Vector::new(1., 1., -0.1)),
+            1,
+            1,
+        );
+    }
+
+    #[test]
+    fn test_vertex_crossing_symmetry_properties() {
+        let a = norm(Vector::new(7., -2., 3.));
+        let b = norm(Vector::new(2., 3., 4.));
+        let d = norm(Vector::new(-1., 2., 5.));
+        assert!(vertex_crossing(&a, &b, &b, &d));
+        assert!(vertex_crossing(&b, &a, &b, &d));
+        assert!(vertex_crossing(&a, &b, &d, &b));
+        assert!(vertex_crossing(&b, &a, &d, &b));
+    }
+
+    #[test]
+    fn test_angle_contains_vertex() {
+        let a = norm(Vector::new(1., 0., 0.));
+        let b = norm(Vector::new(0., 1., 0.));
+        let c = norm(Vector::new(0., 0., 1.));
+        assert!(!angle_contains_vertex(&a, &b, &a));
+        assert!(angle_contains_vertex(&ref_dir(&b), &b, &a));
+        assert!(!angle_contains_vertex(&a, &b, &ref_dir(&b)));
+        assert!(angle_contains_vertex(&a, &b, &c) ^ angle_contains_vertex(&c, &b, &a));
+    }
+}

--- a/src/s2/mod.rs
+++ b/src/s2/mod.rs
@@ -13,6 +13,8 @@ pub mod rect_bounder;
 
 pub mod region;
 
+pub mod edge_crossings;
+pub mod edge_crosser;
 pub mod edgeutil;
 pub mod metric;
 pub mod predicates;


### PR DESCRIPTION
# Summary
Ports S2 edge crossing primitives from the C++ reference implementation into Rust, adding both:

- edge_crossings helpers (crossing predicates + vertex crossing logic)
- EdgeCrosser stateful crosser for efficient chain intersection checks
This is foundational work needed for future polyline support.

# What changed
- Added src/s2/edge_crossings.rs
   - crossing_sign
   - angle_contains_vertex
   - vertex_crossing
   - signed_vertex_crossing
   - edge_or_vertex_crossing
   - signed_edge_or_vertex_crossing
   - robust_cross_prod wrapper
- Added src/s2/edge_crosser.rs
   - Stateful EdgeCrosser with:
     - fixed-edge init/re-init (new, new_with_c, init)
     - chain cursor management (restart_at)
     - crossing APIs (pair + chain forms)
     - signed crossing APIs and last_interior_crossing_sign
   - Fast-path/slow-path structure follows the C++ S2EdgeCrosser flow.
- Updated src/s2/mod.rs to export new modules.