### PR TITLE
Fix clip to padded face

### DIFF
--- a/src/s2/edge_clipping.rs
+++ b/src/s2/edge_clipping.rs
@@ -145,12 +145,12 @@ pub fn clip_to_padded_face(
     }
     norm_uvw = norm_uvw.normalize();
     let a_tan = norm_uvw.cross(&a_uvw);
-    let b_tan = norm_uvw.cross(&b_uvw);
+    let b_tan = b_uvw.cross(&norm_uvw);
 
     // As described in clipDestination, if the sum of the scores from clipping the two
     // endpoints is 3 or more, then the segment does not intersect this face
     let (a_uv, a_score) = clip_destination(b_uvw, a_uvw, scaled_n * -1_f64, b_tan, a_tan, scale_uv);
-    let (b_uv, b_score) = clip_destination(a_uvw, b_uvw, scaled_n * -1_f64, a_tan, b_tan, scale_uv);
+    let (b_uv, b_score) = clip_destination(a_uvw, b_uvw, scaled_n, a_tan, b_tan, scale_uv);
 
     (a_uv, b_uv, a_score + b_score < 3)
 }

--- a/src/s2/edge_clipping.rs
+++ b/src/s2/edge_clipping.rs
@@ -774,6 +774,34 @@ fn next_face(face: u8, exit: r2::point::Point, axis: Axis, n: PointUVW, target_f
 #[cfg(test)]
 pub mod test {
     use super::*;
+
+    #[test]
+    fn test_clip_to_padded_face_edge_cases() {
+        let face: u8 = 0; // +X face (U = Y, V = Z)
+        let padding = 0.0;
+
+        // Case 1: Edge crosses the face boundary (U=2.0 to U=-2.0)
+        let a = Point::from_coords(1.0, 2.0, 0.0).normalize();
+        let b = Point::from_coords(1.0, -2.0, 0.0).normalize();
+        let (a_uv, b_uv, intersects) = super::clip_to_padded_face(a, b, face, padding);
+
+        assert_eq!(intersects, true, "Case 1: Should intersect");
+        assert!((a_uv.x - 1.0).abs() < 1e-9, "Case 1: A_UV x should be 1.0");
+        assert!(
+            (b_uv.x - -1.0).abs() < 1e-9,
+            "Case 1: B_UV x should be -1.0"
+        );
+
+        // Case 2: Edge completely outside the face bounds (U=5.0 to U=4.0)
+        let a_out = Point::from_coords(1.0, 5.0, 0.0).normalize();
+        let b_out = Point::from_coords(1.0, 4.0, 0.0).normalize();
+        let (_, _, intersects_out) = super::clip_to_padded_face(a_out, b_out, face, padding);
+
+        assert_eq!(
+            intersects_out, false,
+            "Case 2: Should correctly reject out-of-bounds edge"
+        );
+    }
     use crate::consts::DBL_EPSILON;
     use crate::s2::random;
     use float_extras::f64::nextafter;


### PR DESCRIPTION
This PR fixes two maths bugs in clip_to_padded_face that caused it to return incorrect values.

- b_tan was calculated with an inverted cross-product order `norm_uvw.cross(&b_uvw)`. It is now computed as `b_uvw.cross(&norm_uvw)`
- the second clip_destination call passed a flipped normal `scaled_n * -1_f64` which inverted the collision logic for the second endpoint. it passes `scaled_n` now.

Reproducing the Bug
The PR includes a test case covering two edge cases:
- A valid edge crossing the face
- An edge completely outside the face bounds (expected to be rejected by clip_destination)

Adding some print statements to that test case (see at the end) i get

on master:
```
case 1: Valid crossing edge
EXPECTED: Intersects: true, A_UV: (1.0, 0.0), B_UV: (-1.0, 0.0)
ACTUAL: Intersects: false, A_UV: (2.0, 0.0), B_UV: (-2.0, 0.0)

case 2: Edge completely outside the face
EXPECTED: Intersects: false
ACTUAL: Intersects: true, A_UV: (1.0, 0.0), B_UV: (1.0, 0.0)
```

after the fix:
```
case 1: Valid crossing edge
EXPECTED: Intersects: true, A_UV: (1.0, 0.0), B_UV: (-1.0, 0.0)
ACTUAL: Intersects: true, A_UV: (1.0, 0.0), B_UV: (-1.0, -0.0)

case 2: Edge completely outside the face
EXPECTED: Intersects: false
ACTUAL: Intersects: false, A_UV: (5.0, 0.0), B_UV: (4.0, 0.0)
```

feel free to check out the first commit here to reproduce the failing test, which is fixed by the followup (second) commit. The code mostly follows the C++ implementation again, like returning somewhat nonsense A and B points on no intersection.

the modified test:
```rust
        #[test]
        fn test_clip_to_padded_face_edge_cases() {
            let face: u8 = 0; // +X face (U = Y, V = Z)
            let padding = 0.0;

            // Case 1: Edge crosses the face boundary (U=2.0 to U=-2.0)
            let a = Point::from_coords(1.0, 2.0, 0.0).normalize();
            let b = Point::from_coords(1.0, -2.0, 0.0).normalize();
            let (a_uv, b_uv, intersects) = super::clip_to_padded_face(a, b, face, padding);

            println!("case 1: Valid crossing edge");
            println!("EXPECTED: Intersects: true, A_UV: (1.0, 0.0), B_UV: (-1.0, 0.0)");
            println!(
                "ACTUAL: Intersects: {}, A_UV: ({:.1}, {:.1}), B_UV: ({:.1}, {:.1})\n",
                intersects, a_uv.x, a_uv.y, b_uv.x, b_uv.y
            );

            // Case 2: Edge completely outside the face bounds (U=5.0 to U=4.0)
            let a_out = Point::from_coords(1.0, 5.0, 0.0).normalize();
            let b_out = Point::from_coords(1.0, 4.0, 0.0).normalize();
            let (a_out_uv, b_out_uv, intersects_out) =
                super::clip_to_padded_face(a_out, b_out, face, padding);

            println!("case 2: Edge completely outside the face");
            println!("EXPECTED: Intersects: false");
            println!(
                "ACTUAL: Intersects: {}, A_UV: ({:.1}, {:.1}), B_UV: ({:.1}, {:.1})\n",
                intersects_out, a_out_uv.x, a_out_uv.y, b_out_uv.x, b_out_uv.y
            );

            assert_eq!(intersects, true, "Case 1: Should intersect");
            assert!((a_uv.x - 1.0).abs() < 1e-9, "Case 1: A_UV x should be 1.0");
            assert!(
                (b_uv.x - -1.0).abs() < 1e-9,
                "Case 1: B_UV x should be -1.0"
            );

            assert_eq!(
                intersects_out, false,
                "Case 2: Should correctly reject out-of-bounds edge"
            );
        }
```