### PR TITLE
Drop unmaintained cgmath dependency (fixes #115)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,9 @@
 
 changelog:
   categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking-change
     - title: 🆕 Enhancements
       labels:
         - enhancement
@@ -17,5 +20,6 @@ changelog:
       exclude:
         labels:
           - bug
+          - breaking-change
           - dependencies
           - enhancement

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ serde = ["dep:serde", "bigdecimal/serde"]
 float_extras = { version = "0.1.6", optional = true }
 lazy_static = "1.4.0"
 rand = { version = "0.10.0", optional = true }
-cgmath = "0.18.0"
 libm = "0.2.6"
 bigdecimal = { version = "0.4.10", default-features = false }
 serde = { version = "1.0.151", features = ["serde_derive"], optional = true }

--- a/src/s2/point.rs
+++ b/src/s2/point.rs
@@ -1,7 +1,5 @@
 use std;
 
-use cgmath::{Matrix, Matrix3, Vector3};
-
 use crate::consts::*;
 use crate::r3::vector::Vector;
 use crate::s1;
@@ -73,24 +71,27 @@ impl std::ops::Mul<f64> for &Point {
     }
 }
 
-impl From<Point> for Vector3<f64> {
-    fn from(p: Point) -> Self {
-        (&p).into()
+impl From<Vector> for Point {
+    fn from(v: Vector) -> Self {
+        Point(v)
     }
 }
-impl<'a> From<&'a Point> for Vector3<f64> {
-    fn from(p: &'a Point) -> Self {
-        Vector3::new(p.0.x, p.0.y, p.0.z)
-    }
+
+/// Frame is an orthonormal 3x3 "frame" matrix, represented as three column
+/// vectors, used to convert points into/out of a local tangent-plane basis.
+/// It is always orthonormal in practice, so its transpose acts as its
+/// inverse.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Frame {
+    pub x: Vector,
+    pub y: Vector,
+    pub z: Vector,
 }
-impl From<Vector3<f64>> for Point {
-    fn from(p: Vector3<f64>) -> Self {
-        (&p).into()
-    }
-}
-impl<'a> From<&'a Vector3<f64>> for Point {
-    fn from(p: &'a Vector3<f64>) -> Self {
-        Point(Vector::new(p.x, p.y, p.z))
+
+impl Frame {
+    /// from_cols builds a Frame from its three column vectors.
+    pub fn from_cols(x: Vector, y: Vector, z: Vector) -> Self {
+        Frame { x, y, z }
     }
 }
 
@@ -180,32 +181,30 @@ impl Point {
     }
 
     // frame returns the orthonormal frame for the given point on the unit sphere.
-    //struct for Frame and From<>/Into<>?
-    //TODO: private
-    pub fn frame(&self) -> Matrix3<f64> {
+    pub(crate) fn frame(&self) -> Frame {
         let c2 = *self;
         let c1 = self.ortho();
         let c0 = Point(c1.0.cross(&self.0));
 
-        Matrix3::from_cols(c0.into(), c1.into(), c2.into())
+        Frame::from_cols(c0.0, c1.0, c2.0)
     }
 }
 
 // from_frame returns the coordinates of the given point in standard axis-aligned basis
 // from its orthonormal basis m.
 // The resulting point p satisfies the identity (p == m * q).
-//TODO: private
-pub fn from_frame(m: &Matrix3<f64>, p: &Point) -> Point {
-    let v: Vector3<f64> = p.into();
-    (m * v).into()
+pub(crate) fn from_frame(m: &Frame, q: &Point) -> Point {
+    Point(m.x * q.0.x + m.y * q.0.y + m.z * q.0.z)
 }
 
 // to_frame returns the coordinates of the given point with respect to its orthonormal basis m.
 // The resulting point q satisfies the identity (m * q == p).
-//TODO: private
-pub fn to_frame(m: &Matrix3<f64>, p: &Point) -> Point {
-    // The inverse of an orthonormal matrix is its transpose.
-    Point::from(m.transpose() * Vector3::from(p))
+// Currently only exercised by tests, kept as the counterpart to from_frame.
+#[allow(dead_code)]
+pub(crate) fn to_frame(m: &Frame, p: &Point) -> Point {
+    // The inverse of an orthonormal matrix is its transpose, so we dot p
+    // against each column of m instead of multiplying by an inverse.
+    Point(Vector::new(p.0.dot(&m.x), p.0.dot(&m.y), p.0.dot(&m.z)))
 }
 
 /// ordered_ccw returns true if the edges OA, OB, and OC are encountered in that
@@ -392,11 +391,7 @@ pub fn regular_points(center: &Point, radius: Angle, num_vertices: usize) -> Vec
 /// with numVertices vertices, all on a circle of the specified angular radius around
 /// the center. The radius is the actual distance from the center to each vertex.
 /// TODO: private?
-fn regular_points_for_frame(
-    frame: &Matrix3<f64>,
-    radius: Angle,
-    num_vertices: usize,
-) -> Vec<Point> {
+fn regular_points_for_frame(frame: &Frame, radius: Angle, num_vertices: usize) -> Vec<Point> {
     // We construct the loop in the given frame coordinates, with the center at
     // (0, 0, 1). For a loop of radius r, the loop vertices have the form
     // (x, y, z) where x^2 + y^2 = sin(r) and z = cos(r). The distance on the
@@ -882,8 +877,6 @@ mod tests {
     }
     */
 
-    use cgmath::SquareMatrix;
-
     // tests for frame
     #[test]
     fn test_point_frames() {
@@ -892,7 +885,9 @@ mod tests {
 
         assert!(Point::from(m.x).0.is_unit());
         assert!(Point::from(m.y).0.is_unit());
-        assert_f64_eq!(m.determinant(), 1.);
+        // Sanity-check that the frame is orthonormal: for an orthonormal
+        // right-handed basis, x cross y == z.
+        assert!(Point(m.x.cross(&m.y)).approx_eq(&Point(m.z)));
 
         assert!(Point(Vector::new(1., 0., 0.)).approx_eq(&to_frame(&m, &Point::from(m.x))));
         assert!(Point(Vector::new(0., 1., 0.)).approx_eq(&to_frame(&m, &Point::from(m.y))));

--- a/src/s2/random.rs
+++ b/src/s2/random.rs
@@ -1,10 +1,9 @@
-use cgmath;
 use std::f64::consts::PI;
 
 use crate::s2::cap::Cap;
 use crate::s2::cellid::*;
 use crate::s2::latlng::LatLng;
-use crate::s2::point::{self, Point};
+use crate::s2::point::{self, Frame, Point};
 use crate::s2::rect::Rect;
 use rand;
 use rand::{Rng, RngExt};
@@ -51,17 +50,17 @@ pub fn rect<R: Rng>(rng: &mut R) -> Rect {
     Rect::from(latlng::<R>(rng)).add(&latlng::<R>(rng))
 }
 
-pub fn frame<R: Rng>(rng: &mut R) -> cgmath::Matrix3<f64> {
+pub fn frame<R: Rng>(rng: &mut R) -> Frame {
     let z = point(rng);
     frame_at_point(rng, z)
 }
 
-pub fn frame_at_point<R: Rng>(rng: &mut R, z: Point) -> cgmath::Matrix3<f64> {
+pub fn frame_at_point<R: Rng>(rng: &mut R, z: Point) -> Frame {
     let p = point(rng);
     let x = z.cross(&p).normalize();
     let y = z.cross(&x).normalize();
 
-    cgmath::Matrix3::from_cols(x.into(), y.into(), z.into())
+    Frame::from_cols(x.0, y.0, z.0)
 }
 
 pub fn cellid<R>(rng: &mut R) -> CellID


### PR DESCRIPTION
## Summary

`cgmath` is unmaintained ([RUSTSEC-2026-0196](https://rustsec.org/advisories/RUSTSEC-2026-0196.html)), which triggers a supply-chain alert for every downstream user of `s2`, even though `s2` only used `cgmath` for one thing: representing an orthonormal 3×3 "frame" matrix for converting points into/out of a local tangent-plane basis.

Since every use is on an orthonormal matrix, this replaces `cgmath::Matrix3<f64>` with dot products against the crate's own `r3::vector::Vector` type, so `cgmath` drops out of `Cargo.toml`/`Cargo.lock` entirely.

## Breaking changes (public API)

- `impl From<Point> for cgmath::Vector3<f64>` and the reverse impl are removed (`cgmath` is gone). A new, unrelated `impl From<Vector> for Point` is added for the crate's own `r3::vector::Vector`.
- `Point::frame()`, `s2::point::from_frame()`, and `s2::point::to_frame()` are **removed from the public API** (not just retyped). Each already carried a `//TODO: private` comment on `master` — they were never meant to be public. This PR is what finally acts on that TODO, using the `cgmath` removal as the occasion. They're now `pub(crate)`, backed by a new `Frame` struct (three `r3::vector::Vector` columns) that itself never becomes reachable from outside the crate.

Since this is a 0.x crate, this ships as a breaking change rather than a deprecation cycle. Labeled `breaking-change` (see below) so it's called out distinctly in release notes.

## Purely internal — no effect on downstream users

- `random::frame()` / `random::frame_at_point()` change their return type from `cgmath::Matrix3<f64>` to the new `Frame` type, but `s2::random` is a private `mod random;` in `s2/mod.rs` (not `pub mod`) and was already unreachable from outside the crate on `master`. Invisible to downstream users.
- `test_point_frames` swaps the `cgmath` `.determinant()` check for a direct orthonormality check (`x.cross(&y) == z`) — internal test only.

## Release notes tooling

Added a `breaking-change` label and a matching "💥 Breaking Changes" category to `.github/release.yml` (placed first, excluded from the "🚧 Maintenance" catch-all), so PRs like this one are called out distinctly instead of blending into "Maintenance". Applied the label to this PR.

## Test plan

`cargo test --all-features`: 240 passed, 0 failed. `cargo build --all-features` clean, no `cgmath` left in `cargo tree`/`Cargo.lock`.

Fixes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)