### PR TITLE
Remove unused optional rand dependency; bump dev rand floor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ serde = ["dep:serde", "bigdecimal/serde"]
 [dependencies]
 float_extras = { version = "0.1.6", optional = true }
 lazy_static = "1.4.0"
-rand = { version = "0.10.0", optional = true }
 libm = "0.2.6"
 bigdecimal = { version = "0.4.10", default-features = false }
 serde = { version = "1.0.151", features = ["serde_derive"], optional = true }
 
 [dev-dependencies]
-rand = { version = "0.10.0" }
+# rand is used only by test-only code (all gated behind #[cfg(test)]),
+# so it's a dev-dependency only, not an optional runtime dependency.
+rand = { version = "0.10.2" }


### PR DESCRIPTION
## Summary

Dependency audit follow-up. `rand = { version = "0.10.0", optional = true }` under `[dependencies]` was dead: it's never gated behind `#[cfg(feature = "rand")]` anywhere, and every actual `rand::` reference in the crate lives inside `#[cfg(test)]` code (including `s2::random`, itself `#[cfg(test)] mod random;`), which already pulls `rand` from `[dev-dependencies]` unconditionally.

## Breaking change (public API)

Removing that optional dependency removes the crate's **implicit `rand` feature flag**. It was never listed in `[features]` — Cargo auto-creates an implicit feature for any optional dependency not otherwise wired in — so `cargo metadata` confirms the feature list shrinks from `[default, float_extras, rand, serde]` to `[default, float_extras, serde]`.

Flagging this `breaking-change` to be precise, per the project's convention of calling out anything that changes the public-facing feature/API surface — even though no downstream code could have observed a behavioral difference from enabling or disabling `s2/rand`, since it gated zero code either way.

## Internal — no public effect

Bumps the `[dev-dependencies]` rand floor from `0.10.0` to `0.10.2`, clearing [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) (low-severity `ThreadRng` reseed unsoundness under a narrow custom-logger scenario, fixed in 0.10.1). This is a dev-only dependency — invisible to downstream users regardless of version.

## Test plan

`cargo test --all-features`: 240 passed, 0 failed. `cargo build --no-default-features`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)