### PR TITLE
Declare MSRV 1.86 and verify it in CI

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,6 +5,7 @@ changelog:
     - title: 💥 Breaking Changes
       labels:
         - breaking-change
+        - msrv
     - title: 🆕 Enhancements
       labels:
         - enhancement
@@ -23,3 +24,4 @@ changelog:
           - breaking-change
           - dependencies
           - enhancement
+          - msrv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,3 +47,24 @@ jobs:
       with:
         fail-on-error: false
       uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329  # v2.3.8
+
+  # Verifies that the crate actually builds on the rust-version declared in
+  # Cargo.toml. If you bump rust-version there, update the pinned toolchain
+  # ref below to match (and label the PR "msrv").
+  msrv:
+    name: Build on minimum supported Rust version
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    # Pinned by branch, not tag: Dependabot won't (and shouldn't) auto-bump this.
+    - name: Install pinned MSRV toolchain
+      uses: dtolnay/rust-toolchain@52699249a776424c51ebc9ee197baf0f9dbf0d8a  # 1.86.0
+    - name: Fetch Rust dependencies
+      run: cargo fetch
+    - name: Build with default features
+      run: cargo build --locked
+    - name: Build with all features
+      run: cargo build --locked --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "s2"
 edition = "2024"
 
+# Raising this is a breaking change: label the PR "msrv" (feeds the
+# "Breaking Changes" release-notes category in .github/release.yml).
+rust-version = "1.86"
+
 version = "0.1.0"
 authors = ["Jihyun Yu <yjh0502@gmail.com>", "Sascha Brawer <sascha@brawer.ch>"]
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Rust port of Google S2 geometry library.
 [![test coverage](https://coveralls.io/repos/github/yjh0502/rust-s2/badge.svg?branch=master)](https://coveralls.io/github/yjh0502/rust-s2?branch=master)
 [![crates.io](https://img.shields.io/crates/v/s2)](https://crates.io/crates/s2)
 [![docs](https://docs.rs/s2/badge.svg)](https://docs.rs/s2/latest/s2/)
+[![MSRV](https://img.shields.io/crates/msrv/s2)](https://crates.io/crates/s2)
 
 # Status of the Rust Library
 


### PR DESCRIPTION
## Summary

Makes explicit the Rust version floor that was previously only implied by `edition = "2024"` (itself requiring >= 1.85). This unblocks the next round of dependency cleanup (`lazy_static` → `std::sync::LazyLock`, `float_extras` → `f64::next_up`/`next_down`, both stable since 1.86) by giving us a documented, CI-enforced floor to build against.

## Breaking change — build environment, not API

Adds `rust-version = "1.86"` to `Cargo.toml`. No public API changes here at all — this is purely about which `rustc` downstream users need to build the crate.

Per Cargo's own SemVer-compatibility conventions, MSRV bumps are generally shipped in a minor release (not requiring a major-version bump), but they can still break a build for someone on an older toolchain, so it's worth calling out distinctly from an API-signature change. Introduced a new `msrv` label that feeds into the same "💥 Breaking Changes" release-notes category as `breaking-change` (`.github/release.yml`), so release notes make "toolchain bump" visually distinct from "API removed" without hiding either. There's a comment right next to `rust-version` in `Cargo.toml` reminding future bumps to apply this label.

Checked every current dependency's own declared `rust_version` — the highest is 1.71 (`syn`/`quote`/`unicode-ident`), so nothing in the dependency graph pushes our floor higher than 1.86.

## CI now actually enforces it

The existing "Unit tests" workflow never pinned a toolchain at all — it just built against whatever Rust ships on `ubuntu-latest`, so a declared MSRV would silently rot the first time a PR used a too-new API, with nobody noticing. Added an `msrv` job that pins exactly `dtolnay/rust-toolchain@1.86.0` and builds the crate (default features, then `--all-features`) on it.

## README

Added a self-updating MSRV badge (`shields.io/crates/msrv/s2`), which reads the published `rust-version` from crates.io metadata directly — avoids a second, hand-written number that could drift out of sync with `Cargo.toml`.

## Test plan

`cargo build`/`cargo test --all-features` pass on the current (much newer) local toolchain. `actionlint` clean on the workflow change. The new CI `msrv` job is the actual verification that 1.86 is sufficient — will show green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)