### PR TITLE
Replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ serde = ["dep:serde", "bigdecimal/serde"]
 
 [dependencies]
 float_extras = { version = "0.1.6", optional = true }
-lazy_static = "1.4.0"
 libm = "0.2.6"
 bigdecimal = { version = "0.4.10", default-features = false }
 serde = { version = "1.0.151", features = ["serde_derive"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;

--- a/src/s1/interval.rs
+++ b/src/s1/interval.rs
@@ -489,39 +489,40 @@ impl From<r1::interval::Interval> for Interval {
 #[allow(dead_code)]
 mod tests {
     use super::*;
+    use std::sync::LazyLock;
 
     // Some standard intervals for use throughout the tests.
-    lazy_static! {
-        static ref full: Interval = FULL;
-        static ref empty: Interval = EMPTY;
-        // Single-point intervals:
-        static ref zero: Interval = Interval::default();
-        static ref pi2: Interval = Interval::new(PI/2., PI/2.);
-        static ref pi: Interval = Interval::new(PI, PI);
-        static ref mipi  :Interval = Interval::new(-PI, -PI); // same as pi after normalization
-        static ref mipi2 :Interval = Interval::new(-PI/2., -PI/2.);
-        // Single quadrants:
-        static ref quad1 :Interval = Interval::new(0., PI/2.);
-        static ref quad2 :Interval = Interval::new(PI/2., -PI); // equivalent to (pi/2., pi)
-        static ref quad3 :Interval = Interval::new(PI, -PI/2.);
-        static ref quad4 :Interval = Interval::new(-PI/2., 0.);
-        // Quadrant pairs:
-        static ref quad12 :Interval = Interval::new(0., -PI);
-        static ref quad23 :Interval = Interval::new(PI/2., -PI/2.);
-        static ref quad34 :Interval = Interval::new(-PI, 0.);
-        static ref quad41 :Interval = Interval::new(-PI/2., PI/2.);
-        // Quadrant triples:
-        static ref quad123 :Interval = Interval::new(0., -PI/2.);
-        static ref quad234 :Interval = Interval::new(PI/2., 0.);
-        static ref quad341 :Interval = Interval::new(PI, PI/2.);
-        static ref quad412 :Interval = Interval::new(-PI/2., -PI);
-        // Small intervals around the midpoints between quadrants,
-        // such that the center of each interval is offset slightly CCW from the midpoint.
-        static ref mid12 :Interval = Interval::new(PI/2.-0.01, PI/2.+0.02);
-        static ref mid23 :Interval = Interval::new(PI-0.01, -PI+0.02);
-        static ref mid34 :Interval = Interval::new(-PI/2.-0.01, -PI/2.+0.02);
-        static ref mid41 :Interval = Interval::new(-0.01, 0.02);
-    }
+    static full: LazyLock<Interval> = LazyLock::new(|| FULL);
+    static empty: LazyLock<Interval> = LazyLock::new(|| EMPTY);
+    // Single-point intervals:
+    static zero: LazyLock<Interval> = LazyLock::new(Interval::default);
+    static pi2: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI / 2., PI / 2.));
+    static pi: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI, PI));
+    static mipi: LazyLock<Interval> = LazyLock::new(|| Interval::new(-PI, -PI)); // same as pi after normalization
+    static mipi2: LazyLock<Interval> = LazyLock::new(|| Interval::new(-PI / 2., -PI / 2.));
+    // Single quadrants:
+    static quad1: LazyLock<Interval> = LazyLock::new(|| Interval::new(0., PI / 2.));
+    static quad2: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI / 2., -PI)); // equivalent to (pi/2., pi)
+    static quad3: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI, -PI / 2.));
+    static quad4: LazyLock<Interval> = LazyLock::new(|| Interval::new(-PI / 2., 0.));
+    // Quadrant pairs:
+    static quad12: LazyLock<Interval> = LazyLock::new(|| Interval::new(0., -PI));
+    static quad23: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI / 2., -PI / 2.));
+    static quad34: LazyLock<Interval> = LazyLock::new(|| Interval::new(-PI, 0.));
+    static quad41: LazyLock<Interval> = LazyLock::new(|| Interval::new(-PI / 2., PI / 2.));
+    // Quadrant triples:
+    static quad123: LazyLock<Interval> = LazyLock::new(|| Interval::new(0., -PI / 2.));
+    static quad234: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI / 2., 0.));
+    static quad341: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI, PI / 2.));
+    static quad412: LazyLock<Interval> = LazyLock::new(|| Interval::new(-PI / 2., -PI));
+    // Small intervals around the midpoints between quadrants,
+    // such that the center of each interval is offset slightly CCW from the midpoint.
+    static mid12: LazyLock<Interval> =
+        LazyLock::new(|| Interval::new(PI / 2. - 0.01, PI / 2. + 0.02));
+    static mid23: LazyLock<Interval> = LazyLock::new(|| Interval::new(PI - 0.01, -PI + 0.02));
+    static mid34: LazyLock<Interval> =
+        LazyLock::new(|| Interval::new(-PI / 2. - 0.01, -PI / 2. + 0.02));
+    static mid41: LazyLock<Interval> = LazyLock::new(|| Interval::new(-0.01, 0.02));
 
     #[test]
     fn test_interval_constructors() {

--- a/src/s2/cell.rs
+++ b/src/s2/cell.rs
@@ -29,10 +29,10 @@ use crate::s2::point::*;
 use crate::s2::region::Region;
 use crate::s2::stuv::*;
 use std::f64::consts::PI;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref POLE_MIN_LAT: f64 = (1. / 3f64).sqrt().asin() - 0.5 * DBL_EPSILON;
-}
+static POLE_MIN_LAT: LazyLock<f64> =
+    LazyLock::new(|| (1. / 3f64).sqrt().asin() - 0.5 * DBL_EPSILON);
 
 /// Cell is an S2 region object that represents a cell. Unlike CellIDs,
 /// it supports efficient containment and intersection tests. However, it is

--- a/src/s2/cellid.rs
+++ b/src/s2/cellid.rs
@@ -25,6 +25,7 @@ use crate::r3::vector::Vector;
 use crate::s2::latlng::*;
 use crate::s2::point::Point;
 use crate::s2::stuv::*;
+use std::sync::LazyLock;
 
 /// CellID uniquely identifies a cell in the S2 cell decomposition.
 /// The most significant 3 bits encode the face number (0-5). The
@@ -864,50 +865,48 @@ pub const IJ_TO_POS: [[u8; 4]; 4] = [[0, 1, 3, 2], [0, 3, 1, 2], [2, 3, 1, 0], [
 pub const POS_TO_IJ: [[u8; 4]; 4] = [[0, 1, 3, 2], [0, 2, 3, 1], [3, 2, 0, 1], [3, 1, 0, 2]];
 pub const POS_TO_ORIENTATION: [u8; 4] = [SWAP_MASK, 0, 0, INVERT_MASK | SWAP_MASK];
 
-lazy_static! {
-    static ref LOOKUP_TBL: [Vec<u64>; 2] = {
-        let size = 1 << (2 * LOOKUP_BITS + 2);
-        let mut lookup_pos = Vec::new();
-        let mut lookup_ij = Vec::new();
-        lookup_pos.resize(size, 0);
-        lookup_ij.resize(size, 0);
+static LOOKUP_TBL: LazyLock<[Vec<u64>; 2]> = LazyLock::new(|| {
+    let size = 1 << (2 * LOOKUP_BITS + 2);
+    let mut lookup_pos = Vec::new();
+    let mut lookup_ij = Vec::new();
+    lookup_pos.resize(size, 0);
+    lookup_ij.resize(size, 0);
 
-        init_lookup_cell(0, 0, 0, 0, 0, 0, &mut lookup_pos, &mut lookup_ij);
-        init_lookup_cell(
-            0,
-            0,
-            0,
-            SWAP_MASK,
-            0,
-            SWAP_MASK,
-            &mut lookup_pos,
-            &mut lookup_ij,
-        );
-        init_lookup_cell(
-            0,
-            0,
-            0,
-            INVERT_MASK,
-            0,
-            INVERT_MASK,
-            &mut lookup_pos,
-            &mut lookup_ij,
-        );
-        init_lookup_cell(
-            0,
-            0,
-            0,
-            SWAP_MASK | INVERT_MASK,
-            0,
-            SWAP_MASK | INVERT_MASK,
-            &mut lookup_pos,
-            &mut lookup_ij,
-        );
-        [lookup_pos, lookup_ij]
-    };
-    static ref LOOKUP_POS: &'static [u64] = LOOKUP_TBL[0].as_slice();
-    static ref LOOKUP_IJ: &'static [u64] = LOOKUP_TBL[1].as_slice();
-}
+    init_lookup_cell(0, 0, 0, 0, 0, 0, &mut lookup_pos, &mut lookup_ij);
+    init_lookup_cell(
+        0,
+        0,
+        0,
+        SWAP_MASK,
+        0,
+        SWAP_MASK,
+        &mut lookup_pos,
+        &mut lookup_ij,
+    );
+    init_lookup_cell(
+        0,
+        0,
+        0,
+        INVERT_MASK,
+        0,
+        INVERT_MASK,
+        &mut lookup_pos,
+        &mut lookup_ij,
+    );
+    init_lookup_cell(
+        0,
+        0,
+        0,
+        SWAP_MASK | INVERT_MASK,
+        0,
+        SWAP_MASK | INVERT_MASK,
+        &mut lookup_pos,
+        &mut lookup_ij,
+    );
+    [lookup_pos, lookup_ij]
+});
+static LOOKUP_POS: LazyLock<&'static [u64]> = LazyLock::new(|| LOOKUP_TBL[0].as_slice());
+static LOOKUP_IJ: LazyLock<&'static [u64]> = LazyLock::new(|| LOOKUP_TBL[1].as_slice());
 
 /// init_lookup_cell initializes the lookupIJ table at init time.
 fn init_lookup_cell(

--- a/src/s2/point.rs
+++ b/src/s2/point.rs
@@ -458,6 +458,7 @@ mod tests {
 
     use crate::s2::stuv::st_to_uv;
     use std::f64::consts::PI;
+    use std::sync::LazyLock;
 
     #[test]
     fn test_default() {
@@ -662,11 +663,9 @@ mod tests {
         y: 1.,
         z: 1.,
     });
-    lazy_static! {
-        // For testing the Girard area fall through case.
-        static ref g2: Point = (g1 + (pr * 1e-15)).normalize();
-        static ref g3: Point = (g1 + (pq * 1e-15)).normalize();
-    }
+    // For testing the Girard area fall through case.
+    static g2: LazyLock<Point> = LazyLock::new(|| (g1 + (pr * 1e-15)).normalize());
+    static g3: LazyLock<Point> = LazyLock::new(|| (g1 + (pq * 1e-15)).normalize());
 
     fn point_area_case(a: &Point, b: &Point, c: &Point, want: f64, nearness: f64) {
         assert!(f64_near(want, point_area(&a, &b, &c), nearness));


### PR DESCRIPTION
## Summary

`lazy_static` hasn't needed to exist since Rust 1.80 stabilized `std::sync::LazyLock`, which does the same job (a static computed once, lazily, on first access) as part of std. Now that `rust-version = "1.86"` is declared (#118), there's no MSRV reason left to keep it around, so this drops the dependency entirely.

Mechanical swap at all 4 call sites:

```rust
lazy_static! { static ref NAME: T = expr; }
    -> static NAME: LazyLock<T> = LazyLock::new(|| expr);
```

- `s2/cell.rs`: `POLE_MIN_LAT` (single static).
- `s2/cellid.rs`: `LOOKUP_TBL`/`LOOKUP_POS`/`LOOKUP_IJ` — `LOOKUP_POS`/`LOOKUP_IJ`'s initializers index into `LOOKUP_TBL`. That still works under `LazyLock` exactly as it did under `lazy_static`: indexing through a `Deref` smart pointer auto-derefs at the receiver, so this is a wrapper-type swap with no behavior change.
- `s2/point.rs`: `g2`/`g3` (test-only, Girard-area fallthrough fixtures).
- `s1/interval.rs`: ~20 named test-only `Interval` fixtures (`full`, `empty`, the quadrant/midpoint intervals, etc.) — expanded from one `lazy_static! { ... }` block into individual `static` declarations, since `LazyLock` has no macro sugar for grouping several at once.

Dropped `extern crate lazy_static` from `lib.rs` and the `lazy_static` entry from `Cargo.toml`.

## Purely internal — no public API change

None of the affected statics were `pub`; all are module-private constants or test-only fixtures. Not a `breaking-change` or `msrv` PR.

## Test plan

`cargo build`/`cargo test --all-features`: 240 passed, 0 failed — unchanged from before. `cargo fmt --all --check`: clean. `cargo build --no-default-features`: clean. `cargo clippy`: no new warnings (only the pre-existing, unrelated `SQRT_2` lint error in `r3/vector.rs` that already exists on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)