### PR TITLE
Replace float_extras with std::f64::next_up/next_down

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,10 @@ documentation = "https://docs.rs/rust-s2"
 keywords = ["geo", "s2"]
 
 [features]
-default = ["serde", "float_extras"]
+default = ["serde"]
 serde = ["dep:serde", "bigdecimal/serde"]
 
 [dependencies]
-float_extras = { version = "0.1.6", optional = true }
 libm = "0.2.6"
 bigdecimal = { version = "0.4.10", default-features = false }
 serde = { version = "1.0.151", features = ["serde_derive"], optional = true }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -41,6 +41,23 @@ pub fn remainder(x: f64, y: f64) -> f64 {
     ::libm::remquo(x, y).0
 }
 
+/// nextafter returns the next representable f64 after x, moving in the
+/// direction of y: y itself if x == y, NaN if either argument is NaN,
+/// otherwise the adjacent representable value one step closer to y. This
+/// mirrors C's nextafter, built on f64::next_up()/next_down() (stable
+/// since Rust 1.86) instead of pulling in a dedicated dependency for it.
+pub fn nextafter(x: f64, y: f64) -> f64 {
+    if x.is_nan() || y.is_nan() {
+        f64::NAN
+    } else if x == y {
+        y
+    } else if x < y {
+        x.next_up()
+    } else {
+        x.next_down()
+    }
+}
+
 pub fn clamp<T>(val: T, min: T, max: T) -> T
 where
     T: PartialOrd,
@@ -70,4 +87,29 @@ where
         }
     }
     i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nextafter() {
+        // Equal inputs: returns y unchanged, regardless of direction.
+        assert_eq!(1.0, nextafter(1.0, 1.0));
+        assert_eq!(0.0, nextafter(0.0, 0.0));
+
+        // Moves by exactly one ULP, in the direction of y.
+        assert_eq!(1.0f64.next_up(), nextafter(1.0, 2.0));
+        assert_eq!(1.0f64.next_down(), nextafter(1.0, 0.0));
+
+        // Crossing zero in either direction steps to the smallest subnormal
+        // of the appropriate sign.
+        assert_eq!(-5e-324, nextafter(0.0, -1.0));
+        assert_eq!(5e-324, nextafter(-0.0, 1.0));
+
+        // NaN in either position propagates to NaN.
+        assert!(nextafter(f64::NAN, 1.0).is_nan());
+        assert!(nextafter(1.0, f64::NAN).is_nan());
+    }
 }

--- a/src/s1/chordangle.rs
+++ b/src/s1/chordangle.rs
@@ -21,9 +21,6 @@ use std::f64::consts::PI;
 use crate::consts::*;
 use crate::s1::angle::*;
 
-#[cfg(feature = "float_extras")]
-use float_extras::f64::nextafter;
-
 /// ChordAngle represents the angle subtended by a chord (i.e., the straight
 /// line segment connecting two points on the sphere). Its representation
 /// makes it very efficient for computing and comparing distances, but unlike
@@ -259,7 +256,6 @@ impl ChordAngle {
         self.sin() / self.cos()
     }
 
-    #[cfg(feature = "float_extras")]
     pub fn successor(&self) -> Self {
         if self.0 >= MAXLENGTH2 {
             ChordAngle::inf()

--- a/src/s2/edge_clipping.rs
+++ b/src/s2/edge_clipping.rs
@@ -802,9 +802,8 @@ pub mod test {
             "Case 2: Should correctly reject out-of-bounds edge"
         );
     }
-    use crate::consts::DBL_EPSILON;
+    use crate::consts::{DBL_EPSILON, nextafter};
     use crate::s2::random;
-    use float_extras::f64::nextafter;
     use rand::{Rng, RngExt};
 
     fn log_uniform<R: Rng>(rng: &mut R, lo: f64, hi: f64) -> f64 {


### PR DESCRIPTION
## Summary

`float_extras` (last published 2017) existed for exactly one function: `nextafter`. Rust 1.86 stabilized `f64::next_up()`/`next_down()`, which is enough to implement it directly — and we just declared `rust-version = "1.86"` (#118), so there's no MSRV reason left to keep the dependency.

Added `consts::nextafter(x, y)`, covered by a new unit test checking it against `next_up()`/`next_down()` directly: equal inputs, moving by one ULP in each direction, crossing zero (steps to the smallest subnormal of the appropriate sign), and NaN propagation from either argument. Both call sites (`ChordAngle::successor` in `s1/chordangle.rs`, and a test helper in `s2/edge_clipping.rs`) now use it unconditionally instead of importing `float_extras::f64::nextafter` behind `#[cfg(feature = "float_extras")]`.

## Breaking change (public API): `float_extras` feature flag removed

`cargo metadata` features shrink from `[default, float_extras, serde]` to `[default, serde]` — `s2/float_extras` is no longer a valid feature to pass. Unlike the `rand` feature removed in #117, this one *did* gate real behavior: `ChordAngle::successor()` previously only existed when the `float_extras` feature was enabled (which was on by default).

That said, this is a strict widening for the default build (the overwhelming majority of users): `successor()` is now always present, where before it only existed under the default feature set. The only way to actually observe a break is passing `features = ["float_extras"]` explicitly, which now fails as an unknown feature. Flagging `breaking-change` to be precise, per repo convention.

## Bonus: fixes a latent `--no-default-features` build gap

`edgeutil.rs`'s test suite calls `ChordAngle::successor()` unconditionally (not gated behind `#[cfg(feature = "float_extras")]`), so `cargo test --no-default-features` would have failed to compile on `master`. Verified it now passes: 241 tests green with `--no-default-features`, same as with `--all-features`.

## Test plan

`cargo build`/`cargo test` with `--all-features` and `--no-default-features`: 241 passed (240 + the new `nextafter` unit test), 0 failed. `cargo fmt --all --check`: clean. `clippy`: no new warnings (only the pre-existing, unrelated `SQRT_2` lint error in `r3/vector.rs` that already exists on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)