### PR TITLE
Add cargo-deny CI job for advisories, licenses, and sources

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,33 @@
+name: cargo-deny
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+  schedule:
+    # Advisories get published against dependencies that haven't changed at
+    # all (that's exactly how #115 happened -- cgmath sat still in Cargo.lock
+    # for years before RUSTSEC-2026-0196 was filed against it), so re-check
+    # weekly even when nothing in this repo has changed.
+    - cron: "0 6 * * 1"
+
+permissions: {}
+
+jobs:
+  cargo-deny:
+    name: Check advisories, licenses, and sources
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Install cargo-deny
+      uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026  # v2.85.11
+      with:
+        tool: cargo-deny
+    # deny.toml scopes this to advisories/licenses/sources; see that file
+    # for what's actually enforced and why.
+    - name: Run cargo deny check
+      run: cargo deny check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,29 @@
+# cargo-deny configuration. Run locally with `cargo deny check`.
+# https://embarkstudios.github.io/cargo-deny/
+#
+# Checks the full resolved dependency tree (all-features) for: known
+# security/unmaintained advisories, disallowed licenses, and dependencies
+# pulled from anywhere other than crates.io.
+
+[graph]
+all-features = true
+
+[advisories]
+# Deny known vulnerabilities and yanked crates; the default lint level
+# already denies both.
+
+[licenses]
+# Every license actually in use today (see full-tree audit in #115-#120):
+# MIT/Apache-2.0-family throughout, plus Unicode-3.0 on unicode-ident.
+allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
+
+[bans]
+# Multiple versions of the same crate are a build-time/binary-size cost,
+# not a correctness problem, so warn rather than fail CI on them.
+multiple-versions = "warn"
+
+[sources]
+# Every dependency should come from crates.io -- fail loudly on anything
+# fetched from git or an unrecognized registry.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary

Everything done in #115-#120 was a manual, one-off sweep — checked via crates.io/OSV API calls, not automation. Nothing would have caught the next `cgmath`-style situation without a human noticing and asking for another look. This wires the same class of checks into CI so it's continuous instead of ad-hoc.

## What `deny.toml` actually enforces

- **advisories**: default (deny) lint level — fails on any RUSTSEC advisory or yanked crate anywhere in the resolved graph.
- **licenses**: allow-list of exactly what's in use today (`MIT`, `Apache-2.0`, `Unicode-3.0` on `unicode-ident`) — fails if a future dependency brings in something incompatible with this crate's own Apache-2.0 license.
- **bans**: `multiple-versions = "warn"`, not deny — duplicate versions are a build-time/binary-size cost, not a correctness problem, so they shouldn't block CI.
- **sources**: deny anything not fetched from crates.io.

## CI

New `.github/workflows/cargo-deny.yml` runs on push/PR (catches a bad dependency the moment a PR introduces it) **and** on a weekly cron (catches a new advisory filed against a dependency that hasn't changed at all — which is exactly how #115 happened: `cgmath` sat untouched in `Cargo.lock` for years before RUSTSEC-2026-0196 was filed against it). Installed via `taiki-e/install-action`, matching the existing `cargo-llvm-cov` pattern already in `tests.yml`.

## Test plan

Verified locally with cargo-deny 0.20.2: `cargo deny check` passes clean (`advisories ok, bans ok, licenses ok, sources ok`) against the full resolved graph, including dev-dependencies — confirmed via `cargo deny -L debug check`: 22 crates gathered, more than the 14 that appear in `cargo deny list`'s display-only summary (that command seems to filter dev-only crates from its report even though `check` itself scans them). `actionlint` clean on the new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)