### PR TITLE
Fix clippy::approx_constant lint on SQRT_2 literal

### DIFF
--- a/src/r3/vector.rs
+++ b/src/r3/vector.rs
@@ -270,7 +270,7 @@ pub enum Axis {
 mod tests {
     use super::*;
     use std::cmp::Ordering;
-    use std::f64::consts::PI;
+    use std::f64::consts::{PI, SQRT_2};
 
     macro_rules! V {
         ($x:expr, $y:expr, $z:expr) => {
@@ -390,7 +390,7 @@ mod tests {
     #[test]
     fn test_vector_distance() {
         assert_f64_eq!(V!(1., 0., 0.).distance(&V!(1., 0., 0.)), 0.);
-        assert_f64_eq!(V!(1., 0., 0.).distance(&V!(0., 1., 0.)), 1.41421356237310);
+        assert_f64_eq!(V!(1., 0., 0.).distance(&V!(0., 1., 0.)), SQRT_2);
         assert_f64_eq!(V!(1., 0., 0.).distance(&V!(0., 1., 1.)), 1.73205080756888);
         assert_f64_eq!(
             V!(1., 1., 1.).distance(&V!(-1., -1., -1.)),


### PR DESCRIPTION
## Summary

`cargo clippy --all-features --all-targets` has been erroring out with `error: approximate value of \`f{32, 64}::consts::SQRT_2\` found` on every check throughout #115-#121 — always a pre-existing, unrelated issue on `master`, so I left it alone until now, as promised.

`test_vector_distance` asserted the distance between two orthogonal unit vectors against a hand-typed `1.41421356237310`. Clippy's `approx_constant` lint (deny-by-default) correctly flags this as "close enough to `std::f64::consts::SQRT_2` that you probably meant to write that." Using the named constant directly instead of a hand-rounded literal.

Purely a test change — no public API impact.

## Test plan

`cargo clippy --all-features --all-targets`: no more errors (previously `error: could not compile \`s2\` (lib test) due to 1 previous error`). `cargo test --all-features`: 241 passed, unchanged. `cargo fmt --all --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)