### PR TITLE
Widen CI clippy step to --all-features --all-targets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,11 @@ jobs:
     - name: Run tests
       run: |
         cargo llvm-cov test --cobertura --verbose --output-path cobertura.xml --features serde
+    # --all-targets so lints inside #[cfg(test)] code are actually checked --
+    # a plain `cargo clippy` never builds test code at all (see #122, where a
+    # deny-by-default lint sat unnoticed in test code because of exactly this).
     - name: Check for lint warnings with Clippy
-      run: cargo clippy --locked
+      run: cargo clippy --all-features --all-targets --locked
     - name: Upload test coverage to Coveralls.io
       with:
         fail-on-error: false


### PR DESCRIPTION
## Summary

Follow-up to #122. Confirmed first, as requested, that widening the scope doesn't surface any other errors: `cargo clippy --all-features --all-targets` and `cargo clippy --no-default-features --all-targets` both exit 0 with zero `error:` lines on top of #122's fix — only pre-existing style warnings, same as before.

Plain `cargo clippy` (what CI ran before this PR) never builds test code at all — that's exactly why the deny-by-default `approx_constant` lint fixed in #122 sat unnoticed on `master` through #115-#121: nothing in CI ever actually linted `#[cfg(test)]` code. `--all-targets` covers tests (and the bin target); `--all-features` matches what the build/test/coverage steps in this same job already effectively use (default features are just `serde` now, and `--all-features` is a superset covering it and anything added later).

## Test plan

Ran the exact new CI command locally: `cargo clippy --all-features --all-targets --locked` → exit 0, no errors, only pre-existing style warnings. `actionlint` clean on the workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)