### PR TITLE
ci: adopt Conventional Commits, automate release notes + labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Conventional Commits (see CONTRIBUTING.md): "chore" so these never
+    # trigger a release-plz version bump on their own.
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,76 @@
+name: Lint PR title
+
+# Enforces the Conventional Commits PR-title convention documented in
+# CONTRIBUTING.md. Since PRs are squash-merged, the PR title becomes the
+# commit message on master -- this is what a future release-plz setup
+# would read to determine version bumps and changelog entries.
+#
+# pull_request_target (not pull_request) so this also runs for PRs from
+# forks: it only reads the PR title from the base repo's workflow config,
+# it doesn't need write access or run any code from the fork.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions: {}
+
+jobs:
+  lint-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+    - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Derives the breaking-change/enhancement/bug label from the PR title so
+  # it doesn't have to be kept in sync by hand (see CONTRIBUTING.md). Only
+  # ever adds a label, never removes one -- a title edit won't strip a
+  # label a human applied for an unrelated reason (e.g. good first issue).
+  # No third-party action for this: the one GitHub itself once pointed
+  # people at (bcoe/conventional-release-labels) only detects breaking
+  # changes via a multi-line "BREAKING CHANGE:" footer, which a one-line PR
+  # title can't contain -- it would silently never fire for us.
+  auto-label:
+    name: Auto-label from PR title
+    runs-on: ubuntu-latest
+    needs: [lint-pr-title]
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Derive and apply label from Conventional Commits type
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Passed via env, never interpolated into the script body: this
+        # title comes from pull_request_target, i.e. it can be attacker-
+        # controlled text from a fork. Templating it directly into `run:`
+        # would be a shell-injection hole; reading it as an env var is
+        # inert data instead.
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        if [[ "$PR_TITLE" =~ ^([a-z]+)(\([a-zA-Z0-9_./-]+\))?(!)?:[[:space:]] ]]; then
+          type="${BASH_REMATCH[1]}"
+          breaking="${BASH_REMATCH[3]}"
+          if [[ -n "$breaking" ]]; then
+            label="breaking-change"
+          elif [[ "$type" == "feat" ]]; then
+            label="enhancement"
+          elif [[ "$type" == "fix" ]]; then
+            label="bug"
+          else
+            label=""
+          fi
+          if [[ -n "$label" ]]; then
+            echo "Applying label: $label"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$label"
+          else
+            echo "Type '$type' has no auto-label mapping; leaving as-is."
+          fi
+        else
+          echo "Title doesn't parse as Conventional Commits; leaving as-is (lint-pr-title should already be failing this PR)."
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,22 @@ jobs:
       run: cargo publish
       env:
         CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Runs only after a successful crates.io publish, so a GitHub Release
+  # never points at a version that isn't actually on crates.io. Uses
+  # --generate-notes, which reads .github/release.yml for categorization
+  # (see CONTRIBUTING.md for the label/commit-prefix conventions that feed
+  # it).
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [publish]
+    permissions:
+      contents: write  # to create the release
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release create "${{ github.ref_name }}" --generate-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,161 @@
+# Contributing to rust-s2 🌐
+
+Thanks for taking a look — contributions of any size are genuinely welcome
+here, whether that’s a typo fix, a bug report, a new test, or porting an
+entire piece of functionality. This document exists so you don’t have to
+guess at the conventions; skim the parts that are relevant to what you’re
+doing and don’t worry about the rest.
+
+## Background & guiding principles 🧭
+
+`s2` traces back through two ancestors:
+
+- [**google/s2geometry**](https://github.com/google/s2geometry) — the
+  original C++ library, and the authoritative source of truth for what the
+  S2 algorithms actually do and why.
+- [**golang/geo**](https://github.com/golang/geo) — a Go port of the C++
+  library, which is what this crate was originally ported *from*.
+
+Looking at the Go port is a fine place to start, but when you’re porting
+or fixing something, please also check the **C++ source** — it’s the
+authoritative implementation, generally better maintained than the Go
+port, which is a step removed from it and occasionally trails or diverges
+in subtle ways. If you’re porting a function, port its tests too (adapted
+to Rust, not copy-pasted): the C++ and Go test suites encode a lot of
+hard-won edge-case knowledge (degenerate geometry, numerical precision
+boundaries, antipodal points, and the like) that’s easy to miss if you’re
+only working from the algorithm description.
+
+That said, this is **not meant to be a literal, line-by-line port**. The
+goal is a Rust API that feels natural to a Rust programmer — using
+`Result`/`Option`, iterators, trait implementations, and ownership the way
+idiomatic Rust code would, rather than mirroring the C++/Go class and
+method structure just because that’s how the source happened to be
+organized. When the idiomatic Rust shape and the original structure
+diverge, prefer the idiomatic Rust shape, and leave a short comment
+pointing at what you ported from so the next person can find their way
+back to the source of truth.
+
+## Getting started 🚀
+
+1. Fork the repo and create a branch for your change.
+2. Make your change (see the guiding principles above if you’re porting or
+   fixing S2 algorithm code).
+3. Before opening a PR, run what CI will check anyway:
+   ```sh
+   cargo fmt --all
+   cargo clippy --all-features --all-targets
+   cargo test --all-features
+   ```
+4. Open a pull request — see the title convention below. Everything else
+   CI will guide you through.
+
+New to the codebase? Issues labeled [`good first
+issue`](https://github.com/yjh0502/rust-s2/labels/good%20first%20issue)
+are a good place to start. Feel free to open an issue first if you’d like
+to talk through an approach before writing code — nobody will mind.
+
+CI also runs two checks that aren’t in the list above, so don’t be
+surprised if either trips you up even though everything passed locally:
+
+- **`cargo-deny`** (`deny.toml`): new dependencies must come from
+  crates.io, use a permissively-licensed license already on the allow
+  list (currently MIT/Apache-2.0/Unicode-3.0), and have no known
+  security advisory. Install with `cargo install cargo-deny` and run
+  `cargo deny check` to verify ahead of time.
+- **MSRV build**: CI also compiles on the exact minimum Rust version this
+  crate declares (`rust-version` in `Cargo.toml`, currently 1.86) — a
+  standard-library API newer than that will build fine on your machine
+  and still fail this job.
+
+## Pull request titles: Conventional Commits 📝
+
+This repo squash-merges PRs, so your PR title becomes the commit message
+on `master`. Please title PRs using [Conventional
+Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>[optional scope][!]: <description>
+```
+
+- `feat:` — a new, backward-compatible public API addition or capability.
+- `fix:` — a bug fix.
+- `chore:`, `ci:`, `refactor:`, `test:`, `build:`, `docs:` — everything with
+  no public-facing effect: CI/tooling changes, internal refactors, tests,
+  documentation. These don’t trigger a release version bump.
+- Append `!` right after the type (and optional scope) for anything that
+  breaks the public API or raises the
+  [MSRV](https://doc.rust-lang.org/cargo/reference/rust-version.html), e.g.
+  `feat!:`, `fix!:`, `chore!:`. Breaking changes bump the *minor* version
+  while this crate is pre-1.0 (`0.x.y` → `0.(x+1).0`), per [Cargo’s SemVer
+  compatibility](https://doc.rust-lang.org/cargo/reference/semver.html) —
+  not the (nonexistent, for a `0.x` crate) major version.
+
+Don’t worry about getting this perfect on the first try: CI checks it
+(`.github/workflows/pr-title-lint.yml`) and will tell you if the title
+needs adjusting, right on the PR.
+
+This convention exists to eventually feed
+[release-plz](https://release-plz.dev), which can fully automate version
+bumps, `CHANGELOG.md` generation, tagging, and publishing from commits
+formatted this way. It isn’t wired up yet, pending a possible repo
+ownership move (see [#49](https://github.com/yjh0502/rust-s2/issues/49)).
+Releases are cut manually until then (see below), but PR titles should
+already follow this convention so that enabling release-plz later is a
+small activation step, not a retrofit.
+
+## GitHub labels 🏷️
+
+PRs are also labeled for GitHub’s auto-generated release notes
+(`.github/release.yml`). CI derives and applies the label from your PR
+title automatically (`.github/workflows/pr-title-lint.yml`), so in the
+common case there’s nothing to do here either:
+
+| Label | Meaning | Auto-applied from |
+|---|---|---|
+| `breaking-change` | Public API changed incompatibly | `!` on the commit type |
+| `enhancement` | New public API/capability, non-breaking | `feat:` |
+| `bug` | Bug fix | `fix:` |
+| `msrv` | Minimum supported Rust version raised | *(manual — see below)* |
+| *(none)* | Purely internal, no public-facing effect | `chore:`/`ci:`/`refactor:`/`test:`/`build:`/`docs:` |
+
+The one exception is `msrv`: it’s a narrow, infrequent special case (an
+MSRV bump is also always `chore!:` and thus already gets `breaking-change`
+automatically) that only a human can reliably recognize, so please add it
+by hand on top when it applies.
+
+### How to tell whether a change is actually breaking
+
+A diff can look identical whether or not the item it touches was ever
+reachable from outside the crate — so don’t infer “breaking” from the
+diff’s shape alone (e.g. “this `pub fn`’s return type changed”). Instead,
+trace the item’s visibility all the way up to the crate root:
+
+- A `pub fn` on a `pub` type still isn’t part of the public API if it
+  lives inside a module that isn’t `pub mod` the whole way up. For
+  example, `s2::random` is declared as a private `mod random;`
+  ([`src/s2/mod.rs`](src/s2/mod.rs)), so nothing inside it — no matter how
+  it’s written — is reachable by a downstream crate; changing it is
+  invisible to them.
+- Conversely, changing something from `pub` to `pub(crate)` *removes* it
+  from the public API even if nothing about its signature otherwise
+  changed — that’s a real break, not an internal detail.
+
+When describing a PR with both kinds of change, it’s worth splitting them
+out explicitly (“breaking” vs. “purely internal, no external effect”)
+rather than describing the diff as one flat list — it’s the difference
+between something a downstream maintainer needs to act on and something
+they’ll never notice.
+
+## Release process 📦
+
+Currently manual:
+
+1. Open a PR bumping `version` in `Cargo.toml` per the SemVer rule above,
+   informed by the categorized diff since the last tag (e.g. via `gh api
+   repos/yjh0502/rust-s2/releases/generate-notes` against the previous tag).
+2. Once merged, tag `master` as `vX.Y.Z` and push the tag.
+3. The tag push triggers `.github/workflows/release.yml`, which runs the
+   test suite, publishes to crates.io (via trusted OIDC publishing — no
+   token to manage), and creates the GitHub Release with generated,
+   categorized notes.


### PR DESCRIPTION
## Summary

Prep work for eventually adopting [release-plz](https://release-plz.dev) (full automated versioning/changelog/publishing), plus two direct fixes: auto-create the GitHub Release on tag push instead of relying on someone remembering to run `gh release create` by hand (`v0.1.0`'s notes only exist because someone did that manually once), and auto-derive the `breaking-change`/`enhancement`/`bug` label from the PR title instead of applying it by hand.

This is itself the first PR to follow the new convention — `ci:` since it's tooling/process only, no crate public-API change.

## Rewritten: `CONTRIBUTING.md`

Friendlier, newbie-oriented pass, plus a new "Background & guiding principles" section: this crate traces through golang/geo back to google/s2geometry (the original C++, and the actual source of truth — checked activity on both repos: C++ has ongoing feature work and real bug fixes from 5+ contributors recently, Go's recent commits are test/style/CI hygiene only from essentially one person, and Go's own top current contributor is also C++'s all-time #1 contributor, so "generally better maintained" is a defensible claim, not just an opinion). Contributors porting or fixing algorithm code should check the C++ source specifically, and port tests alongside implementations since the C++/Go suites encode edge-case knowledge (degenerate geometry, precision boundaries, antipodal points) that's easy to miss otherwise. Explicitly not a literal port, though: the Rust API should read as idiomatic Rust, not a mechanical transliteration.

Also documents: the Conventional Commits PR-title convention, the label auto-derivation below, the current (manual) release process (and *why* release-plz isn't wired up yet — needs admin access this repo's active maintainer doesn't have, see #49), two CI checks that aren't in the local dev-loop (`cargo-deny`'s license/advisory/source enforcement, and the pinned-MSRV build), and a "How to tell whether a change is actually breaking" section — the same reachability-check heuristic used throughout #115-#123 (a diff can look identical whether or not the touched item was ever reachable outside the crate; trace `pub`-ness all the way to the crate root, don't infer from the diff's shape alone), captured here so it's not only in a memory file that a fresh contributor or agent would never see.

Typographic quotes/apostrophes throughout (’ “ ” instead of `'` `"`), kept out of backticked code/URLs/fenced blocks. README gets the same pass in a follow-up PR, kept out of this one to land the CI-related parts first.

## New: `.github/workflows/pr-title-lint.yml`

Two jobs:
- **lint-pr-title**: enforces the convention via `amannn/action-semantic-pull-request` on every PR (`pull_request_target`, `pull-requests: read` — reads the PR title from the base repo's workflow config, doesn't run fork code, no admin/secrets needed).
- **auto-label** (`needs: lint-pr-title`): derives `breaking-change` (any type + `!`) / `enhancement` (`feat:`) / `bug` (`fix:`) from the title and applies it via `gh pr edit --add-label` — additive only, never removes a label a human applied for an unrelated reason. No third-party action for this: the one GitHub itself once pointed people at (`bcoe/conventional-release-labels`) only detects breaking changes via a multi-line `BREAKING CHANGE:` footer, which a one-line PR title structurally can't contain — it would silently never fire for us. The PR title is passed via `env` (`PR_TITLE`), never interpolated into the `run:` script body, since `pull_request_target` processes attacker-controllable text from forks.

## `.github/dependabot.yml`

Configures commit-message prefixes so Dependabot's own PRs already come out Conventional-Commits-shaped: `chore(deps): ...` for cargo, `chore(ci): ...` for github-actions. Both are non-bumping `chore` types, correct since a routine dependency bump shouldn't force a crates.io release by itself.

## `.github/workflows/release.yml`

Adds a `github-release` job that runs after a successful `cargo publish` and creates the GitHub Release with `--generate-notes`, using `contents: write` on the default `GITHUB_TOKEN` (no secret needed).

## Test plan

`actionlint` (+ shellcheck) clean on all three changed/added workflow files. Verified the title-parsing regex against a matrix of real and hypothetical PR titles (feat/fix/chore, with and without scope and `!`, and a pre-convention title) under real bash — all classify correctly. No crate code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)