### PR TITLE
fix: correct docs.rs URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 description = "S2 geometric library"
 homepage = "https://github.com/yjh0502/rust-s2"
 repository = "https://github.com/yjh0502/rust-s2"
-documentation = "https://docs.rs/rust-s2"
+documentation = "https://docs.rs/s2"
 
 keywords = ["geo", "s2"]
 


### PR DESCRIPTION
## Summary

\`documentation\` was set to \`https://docs.rs/rust-s2\`, which 404s — the crate is published as \`s2\`, not \`rust-s2\`, so docs.rs serves it at \`https://docs.rs/s2\` (verified: 302, resolves to the versioned docs page). Only occurrence in the repo; README's docs.rs links already use the correct path.

## Test plan

\`cargo build --all-features\`: clean. Manually verified \`https://docs.rs/s2\` resolves (302) and \`https://docs.rs/rust-s2\` doesn't (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)