### PR TITLE
docs: add CODE_OF_CONDUCT.md and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Code that reproduces the issue, as small as you can make it.
+      render: rust
+  - type: input
+    id: version
+    attributes:
+      label: s2 version
+      placeholder: e.g. 0.1.0
+    validations:
+      required: true
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust version
+      description: Output of `rustc --version`.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,15 @@
+name: Feature request
+description: Suggest new functionality, or porting a piece of the C++/Go S2 library
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like to see?
+      description: >-
+        If this is porting existing S2 functionality, a link to the
+        relevant [C++](https://github.com/google/s2geometry) or
+        [Go](https://github.com/golang/geo) source is very helpful — see
+        CONTRIBUTING.md for why the C++ source specifically matters here.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!-- Thanks for the PR! A couple of things to double check before/while it's open — see CONTRIBUTING.md for the full detail on any of these. -->
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) — it becomes the commit message on `master`, since PRs are squash-merged.
+- [ ] `cargo fmt --all`, `cargo clippy --all-features --all-targets`, and `cargo test --all-features` pass locally.
+- [ ] If this ports or fixes S2 algorithm code: checked against the [C++ source](https://github.com/google/s2geometry) (not just Go), and ported its tests too.
+
+<!-- Delete anything above that doesn't apply. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at sascha@brawer.ch. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Summary

Closes 3 of the 4 gaps GitHub's community-profile check flags for this repo (\`gh api repos/yjh0502/rust-s2/community/profile\`, currently 57%: has README/LICENSE/CONTRIBUTING, missing code_of_conduct/issue_template/pull_request_template).

- **\`CODE_OF_CONDUCT.md\`**: Contributor Covenant v2.1, verbatim (fetched from the upstream repo rather than reconstructed from memory), contact address filled in per Sascha's choice (\`sascha@brawer.ch\`, matching \`Cargo.toml\`'s \`authors\` field).
- **\`.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml\`**: GitHub's modern form-based templates. \`feature_request\` points at both the C++ and Go S2 sources, matching \`CONTRIBUTING.md\`'s guidance on which to check. No \`config.yml\`: GitHub Discussions is disabled on this repo, so there's nothing to add a contact link to beyond the default (blank issues stay allowed).
- **\`.github/PULL_REQUEST_TEMPLATE.md\`**: short checklist mirroring what \`CONTRIBUTING.md\` already documents (Conventional Commits title, local fmt/clippy/test, C++-source check for algorithm ports).

README gets its own pass (including linking to these) in a follow-up, along with the already-deferred typographic-quotes pass and the stale module-completeness status table.

## Test plan

YAML syntax validated for both issue-template files. No crate code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)