### PR TITLE
ci: attest SLSA Build Level 3 provenance for release packages

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,79 @@
+name: Package and attest release provenance
+
+# Reusable workflow, called only by release.yml. Kept as a separate workflow
+# file specifically so this logic can only ever run via workflow_call, under
+# release.yml's own trigger conditions (on: push: tags: ['v*']) -- it cannot
+# be invoked directly with attacker-chosen ref/inputs, which is exactly what
+# SLSA Build Level 3 requires for non-forgeable provenance:
+# https://slsa.dev/spec/v1.2/build-track-basics#build-l3
+#
+# Deliberately split into two jobs, not one: `package` runs cargo's own
+# build machinery (cargo package compiles and verifies the crate, i.e. runs
+# arbitrary crate code -- build scripts, proc macros, etc.) and has no
+# id-token permission at all, so even a fully compromised build can't mint
+# a signing credential. `attest` never runs any crate code -- it only
+# receives a digest computed by `package` and signs *that*. That job
+# boundary, with each job getting its own freshly-minted OIDC token, is
+# what SLSA calls "prevent[ing] secret material used to sign the
+# provenance from being accessible to the user-defined build steps."
+#
+# The actual `cargo publish` to crates.io deliberately stays in release.yml,
+# not here: crates.io's Trusted Publishing config is bound to the exact
+# workflow filename that authenticates, and moving it into this reusable
+# workflow would change that identity and break publishing until someone
+# manually updates the crates.io-side config. release.yml verifies its own
+# `cargo publish` reproduces the digest attested here (see that file).
+#
+# workflow_dispatch is for ad-hoc testing/preview of this packaging+
+# attestation step by a maintainer, independent of cutting an actual
+# release. It requires write access to trigger, so it doesn't reopen the
+# "attacker-chosen inputs" hole that workflow_call-only closes off for
+# lower-trust triggers, like a fork's pull_request.
+on:
+  workflow_dispatch: {}
+  workflow_call:
+    outputs:
+      crate-sha256:
+        description: >-
+          SHA256 digest of the packaged .crate file, for release.yml to
+          verify its own `cargo publish` reproduces the same bytes.
+        value: ${{ jobs.package.outputs.sha256 }}
+      crate-filename:
+        value: ${{ jobs.package.outputs.filename }}
+
+permissions: {}
+
+jobs:
+  package:
+    name: Package crate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+      filename: ${{ steps.hash.outputs.filename }}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Package crate
+      run: cargo package --locked
+    - name: Compute digest
+      id: hash
+      run: |
+        FILE=$(ls target/package/*.crate)
+        echo "filename=$(basename "$FILE")" >> "$GITHUB_OUTPUT"
+        echo "sha256=$(sha256sum "$FILE" | cut -d ' ' -f1)" >> "$GITHUB_OUTPUT"
+
+  attest:
+    name: Attest build provenance
+    runs-on: ubuntu-latest
+    needs: [package]
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+      with:
+        subject-name: ${{ needs.package.outputs.filename }}
+        subject-digest: sha256:${{ needs.package.outputs.sha256 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,24 @@ jobs:
     - name: Run tests
       run: cargo test --release
 
+  # Packages the crate and attests SLSA Build Level 3 provenance for it,
+  # before anything is published -- see release-build.yml's header comment
+  # for why this is a separate reusable workflow rather than jobs inlined
+  # here.
+  attest-provenance:
+    name: Package and attest build provenance
+    needs: [test]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/release-build.yml
+
   # https://crates.io/docs/trusted-publishing
   publish:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [attest-provenance]
     permissions:
       id-token: write  # for OIDC token exchange
     steps:
@@ -33,9 +46,23 @@ jobs:
       uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5
       id: auth
     - name: Publish release
-      run: cargo publish
+      run: cargo publish --locked
       env:
         CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    # cargo publish always repackages internally (it doesn't accept a
+    # pre-built .crate as input), so this confirms it reproduced exactly
+    # the bytes that attest-provenance signed, rather than just assuming
+    # cargo package is deterministic.
+    - name: Verify published bytes match the attested digest
+      run: |
+        FILE=$(ls target/package/*.crate)
+        ACTUAL=$(sha256sum "$FILE" | cut -d ' ' -f1)
+        EXPECTED="${{ needs.attest-provenance.outputs.crate-sha256 }}"
+        if [ "$ACTUAL" != "$EXPECTED" ]; then
+          echo "::error::cargo publish repackaged the crate with different bytes than what was attested (expected $EXPECTED, got $ACTUAL) -- the provenance attestation no longer matches what was published." >&2
+          exit 1
+        fi
+        echo "OK: published bytes match the attested digest ($ACTUAL)"
 
   # Runs only after a successful crates.io publish, so a GitHub Release
   # never points at a version that isn't actually on crates.io. Uses


### PR DESCRIPTION
## Summary

Pattern follows what we already proved out in [alltheplaces/osm-diffs](https://github.com/alltheplaces/osm-diffs) (GitHub's native `actions/attest-build-provenance`, a `workflow_call`-only reusable workflow for isolation), adapted for a crates.io-published library instead of a container image.

The crates.io target changes the honesty of the claim, though: a container registry stores by digest, so anyone pulling `image@sha256:...` gets a mathematically forced match to what was attested. crates.io has no equivalent (no digest-addressed fetch, and per earlier research this session, no native provenance verification at all — [rust-lang/cargo#12661](https://github.com/rust-lang/cargo/issues/12661) proposing SLSA support is closed as not-planned). So this gives real, checkable assurance to someone who explicitly runs `gh attestation verify` against the downloaded `.crate`, and nothing automatic to a plain `cargo add`/`cargo build`.

## New: `.github/workflows/release-build.yml`

Reusable (`workflow_call` + `workflow_dispatch` for ad-hoc testing). Two jobs, deliberately split:
- **package**: runs `cargo package --locked` (compiles + verifies the crate — runs arbitrary crate code: build scripts, proc macros) and has **no** `id-token` permission at all, so a compromised build can't mint a signing credential.
- **attest**: never runs crate code, only receives `package`'s computed digest and signs it via `actions/attest-build-provenance`. Uses `subject-digest` (not `subject-path`), so this job doesn't need the file at all — just the sha256 string as a job output.

That job boundary (each with its own freshly-minted OIDC token) is what SLSA L3 means by isolating build-time secret material from user-defined build steps. The workflow-file boundary (`workflow_call` only, can't be triggered directly with attacker-chosen ref/inputs) is the other L3 requirement, non-falsifiable provenance.

**Deliberately does not** move `cargo publish` into this reusable workflow, unlike osm-diffs' equivalent: crates.io Trusted Publishing is bound to the exact workflow filename that authenticates, and moving the publish step would change that identity and break publishing until someone manually updates the crates.io-side config. Verified this empirically: `cargo package` is byte-for-byte deterministic across repeated runs (identical sha256), but `cargo publish` always reprints "Packaging..." and repackages internally rather than reusing an existing `target/package/*.crate` — so instead of assuming reproducibility, `release.yml`'s publish job now re-hashes what `cargo publish` actually uploaded and fails loudly if it doesn't match the attested digest.

## `.github/workflows/release.yml`

Inserted `attest-provenance` (calls the above) between `test` and `publish`; `publish` now runs `cargo publish --locked` and verifies its output hash against `attest-provenance`'s output before proceeding to `github-release`. Nothing about `publish`'s own job identity changed (same file, same job shape for the auth-relevant parts), so no crates.io reconfiguration needed.

## Test plan

`actionlint` + `shellcheck` clean on both files. Verified `cargo package` determinism locally (two runs, identical sha256). Can't exercise the actual tag-triggered path via a PR (`on: push: tags` doesn't fire for PRs), and tried to test `release-build.yml` via its new `workflow_dispatch` trigger right away — turns out GitHub only allows dispatching a workflow that already exists on the *default* branch, so that has to wait until this actually merges. Plan: dispatch it manually right after merging, before ever cutting a real tagged release, to verify the packaging+attestation mechanism for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)