### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy 🔒
+
+Thanks for helping keep `s2` and its users safe! If you've found a security
+vulnerability, we'd genuinely like to hear about it.
+
+## Reporting a vulnerability 📬
+
+Please report security issues **privately**, by emailing
+**sascha@brawer.ch**, rather than opening a public issue. Include as much
+detail as you can — affected version(s), a reproduction if possible, and
+the potential impact — so it's easier to reproduce and fix quickly.
+
+(GitHub also offers a built-in [private vulnerability
+reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+flow via a repository's Security tab. It isn't usable here yet — reports
+made through it aren't currently visible to the active maintainer — so
+please use email instead until that changes.)
+
+This is a small, mostly-one-person-maintained project 🙂 — there's no
+formal SLA, but security reports get priority attention over everything
+else in the queue.
+
+## Supported versions
+
+Only the most recently published version on
+[crates.io](https://crates.io/crates/s2) is supported. If you're on an
+older version, please upgrade before reporting — the issue may already be
+fixed.
+
+## Supply-chain & release security 🔗
+
+A few things worth knowing about how `s2` gets built and published, for
+anyone doing their own due diligence:
+
+- **Dependency scanning**: every dependency is checked on every PR and
+  weekly (`.github/workflows/cargo-deny.yml`) for known security
+  advisories, incompatible licenses, and untrusted sources — see
+  `deny.toml`.
+- **Trusted Publishing**: releases are published to crates.io via
+  [OIDC-based Trusted
+  Publishing](https://crates.io/docs/trusted-publishing) rather than a
+  long-lived API token — there's no static publishing credential that
+  could leak or be stolen. A release can only be published by the exact,
+  pinned GitHub Actions workflow in this repository.
+- **SLSA Build Level 3 provenance**: every release package is
+  [attested](https://slsa.dev/spec/v1.2/build-track-basics#build-l3) —
+  signed, tamper-evident proof of exactly which commit and workflow
+  produced it, generated in a build environment isolated from the actual
+  build/package steps so a compromised build can't forge its own
+  attestation. Verify a downloaded `.crate` file yourself with
+  [`gh attestation
+  verify`](https://cli.github.com/manual/gh_attestation_verify)
+  (`gh attestation verify s2-X.Y.Z.crate --repo yjh0502/rust-s2`). Note
+  that crates.io itself doesn't check this automatically — `cargo
+  add`/`cargo build` won't verify it for you; this is for anyone who
+  wants to check for themselves.
+
+For how to report a *non-security* bug, see
+[CONTRIBUTING.md](CONTRIBUTING.md) instead.


### PR DESCRIPTION
## Summary

Closes the last community-profile gap (`gh api repos/yjh0502/rust-s2/community/profile`) after #128 handled `code_of_conduct`/`issue_template`/`pull_request_template`.

## Reporting channel

Email (`sascha@brawer.ch`), not GitHub's built-in private vulnerability reporting — verified first that viewing privately-reported advisories requires `admin` or org-level "security manager" role (per GitHub's own permission-levels docs), which the active maintainer doesn't have with `push`+`triage`. Enabling the feature is admin-gated too, and `security_and_analysis` comes back `null` for this repo via the API, consistent with that. So the GitHub mechanism would silently not work for anyone using it; email is what's actually reachable today.

## Supply-chain section

Mentions `cargo-deny` (true today) and Trusted Publishing (true today), plus — now that it's verified — SLSA Build Level 3 provenance (#129): dispatched `release-build.yml` for real after merging #129, and confirmed a genuine, correctly-scoped Sigstore-backed attestation was produced. Decoded the actual in-toto statement and checked `predicateType` (SLSA provenance v1), subject digest, `resolvedDependencies` (correct commit), and `builder.id` (`.../release-build.yml@refs/heads/master`, confirming the job-isolation design actually records the reusable workflow's identity, not `release.yml`'s). Only claiming it in this doc because it's now demonstrated true, not just implemented.

## Tone

No template exists that's both well-established (like Contributor Covenant for `CODE_OF_CONDUCT.md`) and adequately welcoming/friendly for a security policy, so this is original text, aiming for that tone per request; borrowed structural framing (not exact wording) from `alltheplaces/osm-diffs`' `SECURITY.md` where applicable — though that one leans entirely on GitHub's private-reporting flow, which doesn't apply here for the permission reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)