### PR TITLE
docs: rewrite README, audit Rect against C++, file follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,47 @@
-# rust-s2
-
-Rust port of Google S2 geometry library.
+# rust-s2 🌐
 
 [![test coverage](https://coveralls.io/repos/github/yjh0502/rust-s2/badge.svg?branch=master)](https://coveralls.io/github/yjh0502/rust-s2?branch=master)
 [![crates.io](https://img.shields.io/crates/v/s2)](https://crates.io/crates/s2)
 [![docs](https://docs.rs/s2/badge.svg)](https://docs.rs/s2/latest/s2/)
 [![MSRV](https://img.shields.io/crates/msrv/s2)](https://crates.io/crates/s2)
 
-# Status of the Rust Library
+A Rust implementation of [Google’s S2 geometry
+library](https://github.com/google/s2geometry): spherical geometry on the
+surface of a sphere, built around a hierarchical decomposition of the
+sphere into cells. It’s what you reach for when flat-plane geometry isn’t
+good enough — proximity search, region containment, and indexing for
+points, lines, and polygons on the globe.
 
-This library is principally a port of [the Golang S2
-library](https://github.com/golang/geo), adapting to Rust idioms where it makes sense.
-We detail the progress of this port below relative to that Go library.
+## Status 🚧
 
-## [ℝ¹](https://docs.rs/s2/~0/s2/r1/) - One-dimensional Cartesian coordinates
+This is an ongoing port, further along in some areas than others — in
+particular, lines and polygons aren’t implemented yet. Rather than
+maintain a status table here that quietly goes stale, have a look at the
+[issue tracker](https://github.com/yjh0502/rust-s2/issues) for what’s
+implemented, what’s missing, and what’s being worked on.
 
-Full parity with Go.
+## Contributing 🙌
 
-## [ℝ²](https://docs.rs/s2/~0/s2/r2/) - Two-dimensional Cartesian coordinates
+Contributions of any size are very welcome — typo fixes, bug reports,
+new tests, or porting a whole piece of functionality. See
+[CONTRIBUTING.md](CONTRIBUTING.md) to get started; issues labeled
+[`good first
+issue`](https://github.com/yjh0502/rust-s2/labels/good%20first%20issue)
+are a good place to look if you’re new here.
 
-Full parity with Go.
+Please also take a look at our [Code of Conduct](CODE_OF_CONDUCT.md), and
+our [Security Policy](SECURITY.md) if you need to report a vulnerability.
 
-## [ℝ³](https://docs.rs/s2/~0/s2/r3/) - Three-dimensional Cartesian coordinates
+## Credits ❤️
 
-Full parity with Go.
+This library exists thanks to [@yjh0502](https://github.com/yjh0502), who
+started and has driven most of this port, with substantial contributions
+from [@brawer](https://github.com/brawer), [@nside](https://github.com/nside),
+[@Louisvranderick](https://github.com/Louisvranderick), and
+[@HLennart](https://github.com/HLennart) — and everyone else in the
+[contributors graph](https://github.com/yjh0502/rust-s2/graphs/contributors).
+Thank you all! 🎉
 
-## [S¹](https://docs.rs/s2/~0/s2/s1/) - Circular Geometry
+## License ⚖️
 
-Full parity with Go.
-
-## [S²](https://docs.rs/s2/~0/s2/s2/) - Spherical Geometry
-
-**complete**
-
- - Cell, CellID, CellUnion, LatLng, Metric, Point, Region, stuv
-
-**in progress**
-
- - edgeutil, predicates, Rect
-
-**pending**
-
- - loop, paddedcell, polygon, polyline, shapeindex
+Apache-2.0 — see [LICENSE](LICENSE).

--- a/src/s2/rect.rs
+++ b/src/s2/rect.rs
@@ -811,14 +811,24 @@ impl std::fmt::Display for Rect {
     }
 }
 
-/*
+// Re-audited against the C++ source (google/s2geometry's s2latlng_rect.h)
+// on 2026-08-19; see issue #131 for the two genuine gaps below (AddPoint
+// and MayIntersect, previously listed here, are both already implemented:
+// AddPoint as `impl Add<&LatLng> for &Rect`, MayIntersect as
+// `Region::intersects_cell`).
+//
 // TODO: Implement the following, which are present in the C++ version:
-//   - AddPoint(const S2LatLng&)
-//   - ExpandedByDistance(S1Angle)
-//   - GetDistance(const S2LatLngRect&)
-//   - MayIntersect(const S2Cell&)
-//   - Encode, Decode
-*/
+//   - ExpandedByDistance(S1Angle) -- expand along the sphere surface by an
+//     angular distance; distinct from the per-axis expanded() we have.
+//   - GetDistance(const S2LatLngRect&) -- minimum surface distance between
+//     two rects; distinct from the Hausdorff-distance methods we have.
+//
+// Lower priority, not tracked in #131:
+//   - Encode, Decode: C++'s native binary wire format. Different paradigm
+//     from this crate's existing serde support; unclear if worth adding.
+//   - AddPoint(const S2Point&) and the single-S1Angle ApproxEquals overload
+//     are minor convenience overloads on top of the LatLng-based versions
+//     we already have; callers can convert explicitly today.
 
 #[cfg(test)]
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
## Summary

The README's per-module status table had gone stale and inaccurate (exactly what it warns about needing avoided, ironically): `Cap`, `edge_clipping`, `EdgeCrosser`/`edge_crossings` (#103), and `RectBounder` (#44) all exist and were never added to it; `Rect` was listed "in progress" without anyone having actually re-checked what specifically was missing.

## Rect audit (`src/s2/rect.rs`)

Checked against the authoritative C++ source (`google/s2geometry/src/s2/s2latlng_rect.h`), not just Go, per `CONTRIBUTING.md`'s own guidance. The in-file `TODO` comment turned out to be half wrong: `AddPoint` (already done, as `impl Add<&LatLng> for &Rect`) and `MayIntersect` (already done, as `Region::intersects_cell`) were both listed as missing but aren't. Fixed the comment; filed **#131** for the two things that actually are missing (`ExpandedByDistance`, rect-to-rect `GetDistance`) plus two minor overload gaps and a note on `Encode`/`Decode`.

## predicates (not touched, but audited enough to find something)

**#132**: `exact_sign()` — the last-resort fallback in `robust_sign()`'s cascade, meant to definitively resolve orientation via exact-precision arithmetic for the hardest, most degenerate inputs — is a stub that always returns `Indeterminate` regardless of input. That's a real correctness gap, not just missing coverage: inputs that reach this stage currently get a wrong-by-construction answer. Also missing entirely vs Go: `CompareDistances`, `CompareDistance`, `SignDotProd`, `CircleEdgeIntersectionOrdering`.

## edgeutil (not touched, scoped out as too large for today)

**#133**: our `edgeutil.rs` has 4 public functions; Go's equivalent functionality has grown into ~10 files. Some of what Go now splits out is already ported here under different names (`edge_clipping.rs`, `edge_crossings/`) — but `edge_query.go` (closest/furthest-edge queries), `edge_tessellator.go`, and `wedge_relations.go` all look genuinely unstarted.

## Everything else

**#134**: tracks re-verifying the modules previously marked "complete" (`Cell`, `CellID`, `CellUnion`, `LatLng`, `Metric`, `Point`, `Region`, `stuv`) plus adding the never-tracked-but-done ones (`Cap`, `edge_clipping`, `EdgeCrosser`, `RectBounder`, `Shape`) to whatever replaces the table — which, per this PR, is now just a link to the issue tracker instead of a table that can quietly go stale again.

## README rewrite

Per request: brief description of what the library does, links to CONTRIBUTING/CODE_OF_CONDUCT/SECURITY, a Credits section (verified via the GitHub contributors API: yjh0502 110 commits, brawer 64, nside 19, Louisvranderick 5, HLennart 4 — included everyone above the "more than 2-3 changes" bar, linked to the full contributors graph for everyone else), warmer tone throughout, emoji per request. Dropped the R¹/R²/R³/S¹ "full parity with Go" claims along with the S² status table — those were never re-verified today either, so making no claim beats repeating an unverified one.

## Test plan

`cargo build`/`cargo test --all-features`: 241 passed, unchanged. `cargo fmt --all --check`: clean. Every link in the new README (contributor profiles, contributors graph, issue tracker, `google/s2geometry`) returns 200. No other crate code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)