### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # "Breaking Changes" release-notes category in .github/release.yml).
 rust-version = "1.86"
 
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jihyun Yu <yjh0502@gmail.com>", "Sascha Brawer <sascha@brawer.ch>"]
 
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

First step of the documented release process (`CONTRIBUTING.md`): once this merges, tag `master` as `v0.2.0` and push the tag to trigger `release.yml` (test → package + attest SLSA provenance → `cargo publish` → verify published bytes match the attested digest → GitHub Release).

Per [Cargo's SemVer rules for pre-1.0 crates](https://doc.rust-lang.org/cargo/reference/semver.html#change-categories), this is a minor bump despite the breaking changes since v0.1.0 (#116, #117, #118, #120): while at `0.y.z`, an incompatible change bumps `y` rather than jumping to `1.0.0`.

## Test plan

`cargo build --all-features`: clean. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)