### PR TITLE
fix: gate should_panic tests on debug_assertions

### DIFF
--- a/src/s2/edge_crossings/crosser.rs
+++ b/src/s2/edge_crossings/crosser.rs
@@ -274,8 +274,15 @@ mod tests {
     use crate::r3::vector::Vector;
     use crate::s2::point::Point;
 
+    // EdgeCrosser::new() guards against non-unit points via debug_assert!,
+    // which -- like all debug_assert!s -- compiles to a no-op in release
+    // builds. So these only actually panic (and are only meaningful) with
+    // debug assertions enabled; #[cfg(debug_assertions)] keeps them from
+    // failing under `cargo test --release` (as run by the release
+    // pipeline), where the checked invariant is compiled out by design.
     #[test]
     #[should_panic]
+    #[cfg(debug_assertions)]
     fn test_invalid_default_points() {
         let p = Point::default();
         let _crosser = EdgeCrosser::new(&p, &p);
@@ -283,6 +290,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg(debug_assertions)]
     fn test_invalid_nan_points() {
         let nan = std::f64::NAN;
         let p = Point(Vector::new(nan, nan, nan));


### PR DESCRIPTION
## Summary

Discovered by the actual `v0.2.0` release pipeline just now: its `test` job runs `cargo test --release`, which none of our regular CI does (`tests.yml` only ever runs debug-profile `cargo test`). This is the first time these two tests have ever run under `--release`, and they failed there — correctly caught by the pipeline before anything was published (the `publish` job never ran; nothing hit crates.io).

`EdgeCrosser::new()` guards non-unit points via `debug_assert!()`, which — like all `debug_assert!`s — compiles to a no-op under `--release`. The two tests asserting it panics on invalid (default/NaN) points were therefore only ever meaningful in debug builds — `#[cfg(debug_assertions)]` keeps them from running (and failing) under `--release`, where the checked invariant is compiled out by design, not a regression.

Confirmed only these two `#[should_panic]` tests exist anywhere in the crate, so nothing else needs the same fix.

## Test plan

`cargo test --all-features` (debug, matches `tests.yml`): 241 passed, unchanged. `cargo test --release` (matches `release.yml`'s `test` job exactly): 239 passed, 0 failed (241 minus the 2 now debug-only tests). `cargo fmt --all --check` and `cargo clippy --all-features --all-targets`: both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)