### PR TITLE
fix: correct .crate glob path in post-publish verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,15 @@ jobs:
     # pre-built .crate as input), so this confirms it reproduced exactly
     # the bytes that attest-provenance signed, rather than just assuming
     # cargo package is deterministic.
+    #
+    # Note the path: `cargo publish` stages the .crate one directory
+    # deeper than plain `cargo package` does (tmp-crate/, not directly in
+    # target/package/) -- verified locally with cargo 1.97.1. First real
+    # run of this step (v0.2.0) failed with exactly this glob missing the
+    # file, even though the publish itself had already succeeded.
     - name: Verify published bytes match the attested digest
       run: |
-        FILE=$(ls target/package/*.crate)
+        FILE=$(ls target/package/tmp-crate/*.crate)
         ACTUAL=$(sha256sum "$FILE" | cut -d ' ' -f1)
         EXPECTED="${{ needs.attest-provenance.outputs.crate-sha256 }}"
         if [ "$ACTUAL" != "$EXPECTED" ]; then


### PR DESCRIPTION
## Summary

The real v0.2.0 release just hit this: `cargo publish` itself succeeded ("Published s2 v0.2.0 at registry crates-io" — confirmed live on crates.io, matching the attested digest exactly), but the verification step after it failed with `ls: cannot access target/package/*.crate: No such file or directory`, so the pipeline reported failure and never created the GitHub Release, even though the actual release was fine. Worked around it manually (created the GitHub Release by hand, verified the digest matched by other means) — this fixes the pipeline itself for next time.

## Root cause

`cargo publish` stages the `.crate` one directory deeper than plain `cargo package` does — `target/package/tmp-crate/*.crate`, not `target/package/*.crate`. Reproduced locally with cargo 1.97.1 (`cargo publish --dry-run --locked`) to find the right path, then confirmed its sha256 exactly matches the digest already attested for the live v0.2.0 release, so this isn't just a guess.

## Test plan

Reproduced the file layout locally, confirmed the corrected glob resolves and its hash matches the real release's attested digest exactly. `actionlint` + `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)